### PR TITLE
fix: prefer DASH formats to avoid yt-dlp HLS empty file on YouTube

### DIFF
--- a/core/download.py
+++ b/core/download.py
@@ -381,6 +381,7 @@ class Downloader:
             "skip_download": True,
             "force_generic_extractor": True,
             "cookiefile": None,
+            "http_headers": self.headers,
         }
         if self.proxy:
             opts["proxy"] = self.proxy
@@ -409,11 +410,12 @@ class Downloader:
             "outtmpl": str(video_path),
             "merge_output_format": "mp4",
             # "format": f"bv[filesize<={info.duration // 10 + 10}M]+ba/b[filesize<={info.duration // 8 + 10}M]",
-            "format": "best[height<=720]/bestvideo[height<=720]+bestaudio/best",
+            "format": "bv*[height<=720]+ba/b[height<=720]",
             "postprocessors": [
                 {"key": "FFmpegVideoConvertor", "preferedformat": "mp4"}
             ],
             "cookiefile": None,
+            "http_headers": self.headers,
         }
         if self.proxy:
             opts["proxy"] = self.proxy
@@ -441,6 +443,7 @@ class Downloader:
                 }
             ],
             "cookiefile": None,
+            "http_headers": self.headers,
         }
         if self.proxy:
             opts["proxy"] = self.proxy


### PR DESCRIPTION
# AstrBot 插件解析器 (plugin_parser) YouTube 下载报错修复报告

## 问题描述
在使用 AstrBot 的 `astrbot_plugin_parser` 插件解析 YouTube 视频时，出现以下报错：
```text
File "/usr/local/lib/python3.11/site-packages/yt_dlp/downloader/hls.py", line 409, in real_download
    return self.download_and_append_fragments(ctx, fragments, info_dict)
...
yt_dlp.utils.DownloadError: ERROR: The downloaded file is empty
```
该错误表明 `yt-dlp` 在尝试下载 HLS 分片 (fragments) 时获取到了空数据，导致下载失败。这通常是由于 YouTube 服务端策略变更或网络环境导致 HLS 流不稳定所致。

## 环境信息
- **Docker Image**: `soulter/astrbot:latest` (Debian GNU/Linux 13 trixie)
- **Python**: 3.11
- **yt-dlp 版本**: 2025.12.8 (升级前) -> Master Branch (升级后)

## 排查与修复过程

### 1. 依赖补全与升级
为了排除 `yt-dlp` 因缺少 JS 运行时无法通过 YouTube 验证（如 PO Token 验证）的问题，以及修复已知的 HLS 下载 bug，进行了以下操作：
- **安装 Deno**: 作为 `yt-dlp` 推荐的 JavaScript 运行时（版本 2.6.5）。
- **升级 yt-dlp**: 强制升级到 GitHub Master 分支 (`pip install -U https://github.com/yt-dlp/yt-dlp/archive/master.zip`)。
- **安装 yt-dlp[default]**: 确保包含 `yt-dlp-ejs` 等必要依赖。

### 2. 代码逻辑修正 (关键修复)
即便升级了 `yt-dlp`，HLS 下载在特定网络环境下依然不稳定。解决方案是修改插件的下载逻辑，**强制优先使用 DASH 格式 (HTTP Streams)** 而非 HLS 协议。

**修改文件**: `/data/plugins/astrbot_plugin_parser/core/download.py`

**修改点 1: 注入 HTTP Headers**
将插件配置中的 User-Agent 等 Headers 显式传递给 `yt-dlp`，减少被 YouTube 判定为 Bot 的概率。

**修改点 2: 调整 Format Selector**
原配置：
```python
"format": "best[height<=720]/bestvideo[height<=720]+bestaudio/best"
```
该配置在某些情况下会匹配到 HLS 流。

新配置：
```python
"format": "bv*[height<=720]+ba/b[height<=720]"
```
- `bv*`: 选取最佳视频流 (Video only)。
- `+ba`: 加上最佳音频流。
- `/b`: 或者选取最佳单一文件 (fallback)。
- 这种写法能有效避免下载不稳定的 HLS 分片流。

### 3. 代码变更 Diff
```python
    async def ytdlp_extract_info(
        self, url: str, cookiefile: Path | None = None
    ) -> VideoInfo:
        # ...
        opts = {
            # ... 原有配置
            "cookiefile": None,
            "http_headers": self.headers,  # [新增] 传递 headers
        }
        # ...

    async def _ytdlp_download_video(
        self, url: str, cookiefile: Path | None = None
    ) -> Path:
        # ...
        opts = {
            "outtmpl": str(video_path),
            "merge_output_format": "mp4",
            # [修改] 更改 format 规则，优先 DASH，避免 HLS 空文件错误
            "format": "bv*[height<=720]+ba/b[height<=720]", 
            "postprocessors": [
                {"key": "FFmpegVideoConvertor", "preferedformat": "mp4"}
            ],
            "cookiefile": None,
            "http_headers": self.headers, # [新增] 传递 headers
        }
        # ...
```

## 建议
1. 建议项目在 `Dockerfile` 中预装 `Deno` 以支持 `yt-dlp` 的高级验证功能。
2. 建议将上述 `download.py` 的 `format` 修改合并到主分支，以提高下载稳定性。

## Summary by Sourcery

优先使用 DASH 格式并传递 HTTP 请求头，以改进使用 yt-dlp 下载 YouTube 视频的效果。

Bug 修复：
- 通过在下载 YouTube 视频时优先选择 DASH 视频/音频格式，避免由于空的 HLS 下载导致的 yt-dlp 失败。

功能增强：
- 将配置的 HTTP 请求头（包括 User-Agent）传递给 yt-dlp，用于信息提取、视频下载和音频下载，以提升稳定性和兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prefer DASH formats and propagate HTTP headers to improve YouTube downloads with yt-dlp.

Bug Fixes:
- Avoid yt-dlp failures caused by empty HLS downloads by preferring DASH video/audio formats for YouTube downloads.

Enhancements:
- Pass configured HTTP headers (including User-Agent) through to yt-dlp for info extraction, video downloads, and audio downloads to improve reliability and compatibility.

</details>