### PR TITLE
pref: 解析会话采用白名单模式

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,7 +1,7 @@
 {
-    "disabled_sessions": {
-        "description": "关闭解析的会话",
-        "hint": "在会话中使用命令 “开启解析” 和 “关闭解析” 来设置某会话的解析状态",
+    "enabled_sessions": {
+        "description": "开启解析的会话",
+        "hint": "留空表示所有会话都启用本插件的解析功能。在会话中使用命令 “开启解析” 和 “关闭解析” 来设置某会话的解析状态",
         "type": "list",
         "default": []
     },

--- a/core/config.py
+++ b/core/config.py
@@ -120,7 +120,7 @@ class PluginConfig(TypedConfigFacade):
     插件配置
     """
 
-    disabled_sessions: list[str]
+    enabled_sessions: list[str]
     arbiter: bool
     debounce_interval: int
 

--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ class ParserPlugin(Star):
         umo = event.unified_msg_origin
 
         # 禁用会话
-        if umo in self.cfg.disabled_sessions:
+        if self.cfg.enabled_sessions and umo not in self.cfg.enabled_sessions:
             return
 
         # 消息链
@@ -210,23 +210,25 @@ class ParserPlugin(Star):
         # 发送
         await self.sender.send_parse_result(event, parse_res)
 
+    @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("开启解析")
     async def open_parser(self, event: AstrMessageEvent):
         """开启当前会话的解析"""
         umo = event.unified_msg_origin
-        if umo in self.cfg.disabled_sessions:
-            self.cfg.disabled_sessions.remove(umo)
+        if umo not in self.cfg.enabled_sessions:
+            self.cfg.enabled_sessions.append(umo)
             self.cfg.save()
             yield event.plain_result("解析已开启")
         else:
             yield event.plain_result("解析已开启，无需重复开启")
 
+    @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("关闭解析")
     async def close_parser(self, event: AstrMessageEvent):
         """关闭当前会话的解析"""
         umo = event.unified_msg_origin
-        if umo not in self.cfg.disabled_sessions:
-            self.cfg.disabled_sessions.append(umo)
+        if umo in self.cfg.enabled_sessions:
+            self.cfg.enabled_sessions.remove(umo)
             self.cfg.save()
             yield event.plain_result("解析已关闭")
         else:


### PR DESCRIPTION
## Summary by Sourcery

将会话解析切换为基于允许列表（allowlist）的配置，并将解析控制相关命令限制为仅管理员可用。

新功能：
- 添加仅管理员可用的命令，通过启用会话的允许列表，在当前会话中启用或禁用解析。

增强内容：
- 使用启用会话的允许列表（enabled-sessions allowlist）替换原有的禁用会话配置（disabled-sessions），以控制哪些会话会被解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch session parsing to an allowlist-based configuration and gate parse-control commands behind admin permissions.

New Features:
- Add admin-only commands to enable and disable parsing for the current session using an allowlist of enabled sessions.

Enhancements:
- Replace the disabled-sessions configuration with an enabled-sessions allowlist to control which sessions are parsed.

</details>