### PR TITLE
fix: 兼容 AstrBot v4.14.8 并修复 apilmoji 初始化错误

### DIFF
--- a/core/render.py
+++ b/core/render.py
@@ -312,7 +312,6 @@ class Renderer:
             base_url=self.cfg.emoji_cdn,
             style=self.cfg.emoji_style,
             cache_dir=self.cfg.cache_dir / self._EMOJIS,
-            enable_tqdm=True,
         )
         """Emoji Source"""
 

--- a/main.py
+++ b/main.py
@@ -5,8 +5,8 @@ import re
 
 from astrbot.api import logger
 from astrbot.api.event import filter
-from astrbot.api.star import Context, Star
-from astrbot.core import AstrBotConfig
+from astrbot.api.star import Context, Star, register
+from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.message.components import At, Image, Json
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
@@ -24,6 +24,7 @@ from .core.sender import MessageSender
 from .core.utils import extract_json_url
 
 
+@register("astrbot_plugin_parser", "Zhalslar", "万能解析插件", "1.0.0")
 class ParserPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)


### PR DESCRIPTION
#### 修复的 Bug：
1. **TypeError: ParserPlugin.on_message() missing 1 required positional argument: 'event'**
   - **原因**：在 AstrBot v4.14.8 中，插件类必须显式使用 `@register` 装饰器。缺少该装饰器会导致事件监听器无法正确绑定实例 `self`，从而在调用时抛出参数缺失异常。
   - **处理方法**：在 `ParserPlugin` 类上添加 `@register` 装饰器，并更新导入。

2. **TypeError: EmojiCDNSource.__init__() got an unexpected keyword argument 'enable_tqdm'**
   - **原因**：由于上游依赖 `apilmoji` 库的更新，`EmojiCDNSource` 的构造函数不再支持 `enable_tqdm` 参数。
   - **处理方法**：移除 `core/render.py` 中 `EmojiCDNSource` 初始化的 `enable_tqdm=True` 参数。

3. **初始化参数类型修复**
   - **处理方法**：修正 `AstrBotConfig` 的导入路径。

关联 Issue: #69

## Summary by Sourcery

通过更新插件注册方式并调整 emoji CDN 初始化，确保与 AstrBot v4.14.8 的兼容性。

Bug 修复：
- 通过使用 AstrBot 插件装饰器注册 `ParserPlugin`，修复插件事件处理器绑定问题。
- 通过在构建 `EmojiCDNSource` 时移除不受支持的 `enable_tqdm` 参数，解决 apilmoji 初始化错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure compatibility with AstrBot v4.14.8 by updating plugin registration and adjusting emoji CDN initialization.

Bug Fixes:
- Fix plugin event handler binding by registering ParserPlugin with the AstrBot plugin decorator.
- Resolve apilmoji initialization error by removing the unsupported enable_tqdm argument from EmojiCDNSource construction.

</details>