### PR TITLE
Fix: EmojiCDNSource 初始化参数名称不匹

### DIFF
--- a/core/render.py
+++ b/core/render.py
@@ -312,7 +312,7 @@ class Renderer:
             base_url=self.cfg.emoji_cdn,
             style=self.cfg.emoji_style,
             cache_dir=self.cfg.cache_dir / self._EMOJIS,
-            enable_tqdm=True,
+            show_progress=True,
         )
         """Emoji Source"""
 


### PR DESCRIPTION
修复AstrBot 更新至 v4.15.0 后，插件加载失败：
  TypeError: EmojiCDNSource.__init__() got an unexpected keyword argument
  'enable_tqdm'
 AstrBot v4.15.0 更新了内置的 apilmoji 库，EmojiCDNSource 的进度条参数名由
  enable_tqdm 改为 show_progress。

## Summary by Sourcery

错误修复：
- 通过将 EmojiCDNSource 构造函数参数与更新后的 apilmoji API 对齐，修复在 AstrBot v4.15.0 中插件初始化失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix plugin initialization failure with AstrBot v4.15.0 by aligning EmojiCDNSource constructor argument with the updated apilmoji API.

</details>