### PR TITLE
通用发送框架：为 ParseResult 增加分组发送能力

### DIFF
--- a/core/data.py
+++ b/core/data.py
@@ -87,7 +87,7 @@ class TextContent(MediaContent):
     text: str
 
     def __init__(self, text: str):
-        super().__init__(Path("."))
+        MediaContent.__init__(self, Path("."))
         self.text = text
 
     async def get_path(self) -> Path:

--- a/core/sender.py
+++ b/core/sender.py
@@ -242,7 +242,7 @@ class MessageSender:
         text = "\n".join(line for line in lines if line).strip()
         return [Plain(text)] if text else []
 
-    def _resolve_groups(result: ParseResult) -> list[SendGroup]:
+    def _resolve_groups(self, result: ParseResult) -> list[SendGroup]:
         if result.send_groups:
             return result.send_groups
         return [SendGroup(contents=list(MessageSender._iter_contents(result)))]


### PR DESCRIPTION
## 概要

这个 PR 只包含通用框架层的调整，不包含任何小黑盒平台特判，目标是为后续解析器提供可复用的分组发送能力。

## 改动内容

- 在 `core/data.py` 中增加通用的 `TextContent` / `SendGroup`
- 在 `core/sender.py` 中增加对 `send_groups` 的通用处理逻辑
- 保持向后兼容：未提供 `send_groups` 的现有解析器仍走原有发送路径
- 修复通用发送辅助逻辑中的初始化/方法签名问题

## 设计原则

- 不在 sender 中写入任何平台专属逻辑
- 由 parser 通过通用结构表达“怎么发”，sender 只负责执行
- 尽量减少对已有解析器行为的影响

## 影响文件

- `core/data.py`
- `core/sender.py`

## 说明

后续我会基于这个通用能力，单独提交小黑盒解析器 PR。那个 PR 会只处理小黑盒解析与配置，不再修改通用 sender 框架。

## Summary by Sourcery

在消息发送框架中新增通用的分组发送能力，同时对未选择加入的解析器保持现有行为不变。

新功能：
- 引入 `TextContent` 媒体类型，使解析器可以将纯文本作为标准的可发送内容进行输出。
- 在 `ParseResult` 上新增 `SendGroup` 和 `send_groups` 支持，用于描述发送方可以按顺序执行的分组发送计划。

增强内容：
- 扩展发送计划构建器和分段构造逻辑，以处理 `TextContent`，并尊重每个分组的 `force_merge` 和 `render_card` 覆盖设置。
- 在未生成任何分段时，引入纯文本回退发送路径，从而提升消息发送的健壮性。
- 优化 `ParseResult` 的资源 ID 计算逻辑，将文本内容和发送分组元数据纳入考虑，以提升缓存键的唯一性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add generic grouped sending capabilities to the message sending framework while preserving existing behavior for parsers that do not opt in.

New Features:
- Introduce a TextContent media type so parsers can emit plain text as standard sendable content.
- Add SendGroup and send_groups support on ParseResult to describe grouped send plans that the sender can execute in order.

Enhancements:
- Extend the send plan builder and segment construction to handle TextContent and respect per-group force_merge and render_card overrides.
- Introduce a fallback text-only send path when no segments are generated, improving resiliency of message sending.
- Refine ParseResult resource ID computation to incorporate text contents and send group metadata for better cache uniqueness.

</details>