### PR TITLE
bilibili解析器增加回退机制

### DIFF
--- a/core/parsers/bilibili/__init__.py
+++ b/core/parsers/bilibili/__init__.py
@@ -413,9 +413,15 @@ class BilibiliParser(BaseParser):
         # 获取下载数据
         download_url_data = await video.get_download_url(page_index=page_index)
         detecter = VideoDownloadURLDataDetecter(download_url_data)
+        codec_candidates = [self.video_codecs, VideoCodecs.AV1, VideoCodecs.HEV, VideoCodecs.AVC]
+        codec_priority = []
+        for c in codec_candidates:
+            if c not in codec_priority:
+                codec_priority.append(c)
+
         streams = detecter.detect_best_streams(
             video_max_quality=self.video_quality,
-            codecs=[self.video_codecs],
+            codecs=codec_priority,
             no_dolby_video=True,
             no_hdr=True,
         )


### PR DESCRIPTION
加了一个优先级列表，最先的是自选的编码格式，然后按照av1-hevc-avc的顺序进行一次去重
这样首选的编码格式没有的话，会自动回退到其他的编码

## 由 Sourcery 提供的摘要

新功能：
- 在 Bilibili 解析器中引入优先级编解码器列表，当首选编解码器不可用时，可按需自动回退至 AV1、HEVC，再到 AVC。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a prioritized codec list in the Bilibili parser to automatically fall back from the preferred codec to AV1, HEVC, then AVC as needed.

</details>