### PR TITLE
fix: fetch_emoji_like 兼容 LLBot

### DIFF
--- a/core/arbiter.py
+++ b/core/arbiter.py
@@ -150,8 +150,10 @@ class EmojiLikeArbiter:
         try:
             resp = await bot.fetch_emoji_like(
                 message_id=message_id,
+                emoji_id=str(emoji_id),
                 emojiId=str(emoji_id),
                 emojiType=emoji_type,
+                count=20,
             )
         except Exception:
             return []


### PR DESCRIPTION
## 问题

仲裁器 (`EmojiLikeArbiter`) 的 `fetch_emoji_like` 调用使用了 NapCat 风格的 camelCase 参数名 (`emojiId`)，但 [LLBot (LuckyLilliaBot)](https://github.com/LLOneBot/LuckyLilliaBot) 的 `fetch_emoji_like` 使用 snake_case 参数名 (`emoji_id`)。

LLBot 的 payload schema ([源码](https://github.com/LLOneBot/LuckyLilliaBot/blob/main/src/onebot11/action/llbot/msg/FetchEmojiLike.ts))：
```ts
payloadSchema = {
    emoji_id: string().required(),  // snake_case
    message_id: union([Number, String]).required(),
    count: union([Number, String]).default(20)
}
```

当 Bot 通过 LLBot 连接时，`emoji_id` 缺失导致 schema 验证失败，异常被 `except Exception` 静默捕获，`_fetch_users` 始终返回空列表。结果：**仲裁完全失效，所有 Bot 都认为自己胜出，重复解析同一链接。**

`set_msg_emoji_like` 不受影响（NapCat 和 LLBot 都接受 `emoji_id`）。

## 修复

同时传递两种参数名（`emoji_id` + `emojiId`），各实现取所需、忽略未知参数：

```python
resp = await bot.fetch_emoji_like(
    message_id=message_id,
    emoji_id=str(emoji_id),   # LLBot
    emojiId=str(emoji_id),    # NapCat
    emojiType=emoji_type,     # NapCat
    count=20,
)
```

## 验证

- NapCat (mlikiowa/napcat-docker:latest) ✅ 仲裁正常
- LLBot (linyuchen/llbot:7.12.11) ✅ 仲裁正常（修复前失效）

## Summary by Sourcery

Bug Fixes:
- 修复由于 `fetch_emoji_like` 参数名称不匹配，导致在使用 LLBot 时表情符号类似仲裁失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix emoji-like arbitration failing with LLBot due to mismatched fetch_emoji_like parameter names.

</details>