### PR TITLE
fix: map local media paths before sending

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -120,13 +120,13 @@
     },
     "local_media_path_prefix": {
         "description": "本机媒体路径前缀",
-        "hint": "可选。AstrBot 与 OneBot/NapCat 不在同一文件系统时使用，例如 AstrBot 本机路径 /docker-file/AstrBot/data。留空则不转换。",
+        "hint": "可选。AstrBot 与 OneBot 实现不共享相同绝对路径时使用。填写 AstrBot 侧保存媒体文件的路径前缀。留空则不转换。",
         "type": "string",
         "default": ""
     },
     "send_media_path_prefix": {
         "description": "发送端媒体路径前缀",
-        "hint": "可选。对应 OneBot/NapCat 容器内可访问的路径，例如 /AstrBot/data。只有同时配置本机媒体路径前缀时生效。",
+        "hint": "可选。填写 OneBot 实现侧访问同一媒体文件时使用的路径前缀。只有同时配置本机媒体路径前缀时生效。留空则不转换。",
         "type": "string",
         "default": ""
     },

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -118,6 +118,18 @@
         "type": "string",
         "default": ""
     },
+    "local_media_path_prefix": {
+        "description": "本机媒体路径前缀",
+        "hint": "可选。AstrBot 与 OneBot/NapCat 不在同一文件系统时使用，例如 AstrBot 本机路径 /docker-file/AstrBot/data。留空则不转换。",
+        "type": "string",
+        "default": ""
+    },
+    "send_media_path_prefix": {
+        "description": "发送端媒体路径前缀",
+        "hint": "可选。对应 OneBot/NapCat 容器内可访问的路径，例如 /AstrBot/data。只有同时配置本机媒体路径前缀时生效。",
+        "type": "string",
+        "default": ""
+    },
     "clean_cron": {
         "description": "自动清理缓存的触发周期",
         "hint": "使用 Cron 表达式（分 时 日 月 周）定义。例如：“30 2 * * *” 表示每天 2:30 。留空表示禁用自动清理",

--- a/core/config.py
+++ b/core/config.py
@@ -209,6 +209,8 @@ class PluginConfig(ConfigNode):
     common_timeout: int
 
     proxy: str | None
+    local_media_path_prefix: str | None
+    send_media_path_prefix: str | None
 
     clean_cron: str
 
@@ -227,6 +229,8 @@ class PluginConfig(ConfigNode):
 
         # ---------- 派生字段 ----------
         self.proxy = self.proxy or None
+        self.local_media_path_prefix = self.local_media_path_prefix or None
+        self.send_media_path_prefix = self.send_media_path_prefix or None
         self.max_duration = self.source_max_minute * 60
         self.max_size = self.source_max_size * 1024 * 1024
 

--- a/core/config.py
+++ b/core/config.py
@@ -155,6 +155,7 @@ class ParserItem(ConfigNode):
     cookies: str | None
     show_body_text: bool | None
     video_send_mode: str | None
+    video_codecs: str | None
     video_codec_list: list | None
     video_quality: str | None
 

--- a/core/parsers/bilibili/__init__.py
+++ b/core/parsers/bilibili/__init__.py
@@ -44,9 +44,10 @@ class BilibiliParser(BaseParser):
         self.video_quality = getattr(
             VideoQuality, str(self.mycfg.video_quality).upper(), VideoQuality._720P
         )
+        codec_names = self.mycfg.video_codec_list or [self.mycfg.video_codecs or "AVC"]
         self.video_codecs = [
             getattr(VideoCodecs, str(c).upper(), VideoCodecs.AVC)
-            for c in (self.mycfg.video_codec_list or ["AVC"])
+            for c in codec_names
         ]
         self.login = BilibiliLogin(config)
 
@@ -433,6 +434,5 @@ class BilibiliParser(BaseParser):
             return video_stream.url, None
         logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
         return video_stream.url, audio_stream.url
-
 
 

--- a/core/sender.py
+++ b/core/sender.py
@@ -57,7 +57,20 @@ class MessageSender:
     def _to_file_uri(self, path: Path) -> str:
         if not path.is_absolute():
             path = path.resolve()
+        path = self._map_send_path(path)
         return path.as_uri()
+
+    def _map_send_path(self, path: Path) -> Path:
+        local_prefix = self.cfg.local_media_path_prefix
+        send_prefix = self.cfg.send_media_path_prefix
+        if not local_prefix or not send_prefix:
+            return path
+
+        try:
+            relative_path = path.relative_to(Path(local_prefix))
+        except ValueError:
+            return path
+        return Path(send_prefix) / relative_path
 
     @staticmethod
     def _iter_contents(result: ParseResult):

--- a/tests/test_sender_path_mapping.py
+++ b/tests/test_sender_path_mapping.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def sender_module(monkeypatch: pytest.MonkeyPatch):
+    logger = SimpleNamespace(error=lambda *args, **kwargs: None)
+
+    astrbot_pkg = types.ModuleType("astrbot")
+    astrbot_pkg.__path__ = []
+    api_module = types.ModuleType("astrbot.api")
+    api_module.logger = logger
+
+    components_module = types.ModuleType("astrbot.core.message.components")
+    platform_module = types.ModuleType("astrbot.core.platform.astr_message_event")
+
+    class BaseMessageComponent:
+        pass
+
+    class _Component(BaseMessageComponent):
+        def __init__(self, *args, **kwargs):
+            pass
+
+    for name in (
+        "File",
+        "Image",
+        "Node",
+        "Nodes",
+        "Plain",
+        "Record",
+        "Video",
+    ):
+        setattr(components_module, name, type(name, (_Component,), {}))
+    components_module.BaseMessageComponent = BaseMessageComponent
+
+    class AstrMessageEvent:
+        pass
+
+    platform_module.AstrMessageEvent = AstrMessageEvent
+
+    monkeypatch.setitem(sys.modules, "astrbot", astrbot_pkg)
+    monkeypatch.setitem(sys.modules, "astrbot.api", api_module)
+    monkeypatch.setitem(sys.modules, "astrbot.core.message.components", components_module)
+    monkeypatch.setitem(sys.modules, "astrbot.core.platform.astr_message_event", platform_module)
+    monkeypatch.setitem(sys.modules, "core.config", types.ModuleType("core.config"))
+    monkeypatch.setitem(sys.modules, "core.config", SimpleNamespace(PluginConfig=object))
+    monkeypatch.setitem(sys.modules, "core.render", SimpleNamespace(Renderer=object))
+
+    monkeypatch.delitem(sys.modules, "core.sender", raising=False)
+    return importlib.import_module("core.sender")
+
+
+def test_file_uri_uses_configured_send_path_prefix(sender_module):
+    sender = sender_module.MessageSender.__new__(sender_module.MessageSender)
+    sender.cfg = SimpleNamespace(
+        local_media_path_prefix="/docker-file/AstrBot/data",
+        send_media_path_prefix="/AstrBot/data",
+    )
+
+    uri = sender._to_file_uri(
+        Path("/docker-file/AstrBot/data/plugin_data/astrbot_plugin_parser/cache/a.mp4")
+    )
+
+    assert uri == "file:///AstrBot/data/plugin_data/astrbot_plugin_parser/cache/a.mp4"
+
+
+def test_file_uri_is_unchanged_without_mapping(sender_module):
+    sender = sender_module.MessageSender.__new__(sender_module.MessageSender)
+    sender.cfg = SimpleNamespace(
+        local_media_path_prefix="",
+        send_media_path_prefix="",
+    )
+
+    uri = sender._to_file_uri(Path("/tmp/a.mp4"))
+
+    assert uri == "file:///tmp/a.mp4"


### PR DESCRIPTION
When AstrBot and OneBot/NapCat do not share the same absolute filesystem paths, downloaded media can be saved successfully but video/file sends fail because the adapter passes a local file URI that is not visible to the sender process.\n\nAdd optional local_media_path_prefix and send_media_path_prefix settings. If both are configured, MessageSender rewrites media paths under the local prefix before building file:// URIs. Existing behavior is unchanged when the settings are empty.\n\nVerified with host-run AstrBot using /docker-file/AstrBot/data and Docker NapCat seeing the same volume as /AstrBot/data. Added unit tests for mapped and unmapped URI behavior.

## Summary by Sourcery

为媒体 URI 添加可配置的媒体路径映射，以确保在不同宿主机和容器文件系统下发送的 `file://` 路径始终有效。

New Features:
- 引入可选配置字段 `local_media_path_prefix` 和 `send_media_path_prefix`，用于控制在发送前如何重写本地媒体路径。

Bug Fixes:
- 当 AstrBot 和适配器运行在不同的绝对文件系统路径下时，通过将本地媒体路径映射为可见的发送前缀，确保媒体发送能够成功。

Tests:
- 添加单元测试，验证在配置了映射时 `file` URI 会被重写，而在禁用映射时则保持不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable media path mapping for media URIs to ensure sent file:// paths are valid across differing host and container filesystems.

New Features:
- Introduce optional local_media_path_prefix and send_media_path_prefix configuration fields to control how local media paths are rewritten before sending.

Bug Fixes:
- Ensure media sends succeed when AstrBot and the adapter run with different absolute filesystem paths by mapping local media paths to the visible send prefix.

Tests:
- Add unit tests verifying that file URIs are rewritten when mapping is configured and remain unchanged when mapping is disabled.

</details>