### PR TITLE
fix: accept legacy bilibili codec config

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -155,6 +155,7 @@ class ParserItem(ConfigNode):
     cookies: str | None
     show_body_text: bool | None
     video_send_mode: str | None
+    video_codecs: str | None
     video_codec_list: list | None
     video_quality: str | None
 

--- a/core/parsers/bilibili/__init__.py
+++ b/core/parsers/bilibili/__init__.py
@@ -44,9 +44,10 @@ class BilibiliParser(BaseParser):
         self.video_quality = getattr(
             VideoQuality, str(self.mycfg.video_quality).upper(), VideoQuality._720P
         )
+        codec_names = self.mycfg.video_codec_list or [self.mycfg.video_codecs or "AVC"]
         self.video_codecs = [
             getattr(VideoCodecs, str(c).upper(), VideoCodecs.AVC)
-            for c in (self.mycfg.video_codec_list or ["AVC"])
+            for c in codec_names
         ]
         self.login = BilibiliLogin(config)
 
@@ -433,6 +434,5 @@ class BilibiliParser(BaseParser):
             return video_stream.url, None
         logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
         return video_stream.url, audio_stream.url
-
 
 


### PR DESCRIPTION
## Summary
- add the legacy Bilibili `video_codecs` config field back to the parser config type
- fall back to `video_codecs` when `video_codec_list` is absent, preserving compatibility with existing configs

## Notes
- this PR intentionally does not include any path mapping changes