### PR TITLE
支持抖音分享页 SSR 免签解析路径，并修复本地媒体发送时的文件路径问题。

### DIFF
--- a/core/parsers/douyin/__init__.py
+++ b/core/parsers/douyin/__init__.py
@@ -65,6 +65,10 @@ class DouyinParser(BaseParser):
         hostname = urlparse(url).hostname or ""
         return hostname == "iesdouyin.com" or hostname.endswith(".iesdouyin.com")
 
+    def _has_ttwid(self) -> bool:
+        cookies = self.cookiejar.get(domain="iesdouyin.com") or {}
+        return bool(cookies.get("ttwid"))
+
     # https://v.douyin.com/_2ljF4AmKL8
     @handle("v.douyin", r"v\.douyin\.com/[a-zA-Z0-9_\-]+")
     @handle("jx.douyin", r"jx\.douyin\.com/[a-zA-Z0-9_\-]+")
@@ -111,7 +115,7 @@ class DouyinParser(BaseParser):
         return f"https://m.douyin.com/share/{ty}/{vid}/"
 
     async def ensure_ttwid(self) -> None:
-        if self.cookiejar.get(domain="iesdouyin.com").get("ttwid"):
+        if self._has_ttwid():
             return
 
         logger.debug("[抖音] 当前缺少匿名 ttwid，尝试注册")
@@ -135,7 +139,6 @@ class DouyinParser(BaseParser):
                 self.TTWID_REGISTER_URL,
                 json=payload,
                 headers=headers,
-                ssl=False,
             ) as resp:
                 if resp.status >= 400:
                     raise ParseException(f"ttwid register status: {resp.status}")
@@ -143,7 +146,7 @@ class DouyinParser(BaseParser):
                 self.cookiejar.update_from_response(set_cookie_headers)
                 self._set_cookies()
                 body = await resp.json(content_type=None)
-        except (ClientError, ValueError) as e:
+        except (ClientError, TimeoutError, ValueError) as e:
             raise ParseException("ttwid register failed") from e
 
         if not isinstance(body, dict):
@@ -157,24 +160,23 @@ class DouyinParser(BaseParser):
                     callback_url,
                     headers=callback_headers,
                     allow_redirects=False,
-                    ssl=False,
                 ) as resp:
                     if resp.status >= 400:
                         raise ParseException(f"ttwid callback status: {resp.status}")
                     set_cookie_headers = resp.headers.getall("Set-Cookie", [])
                     self.cookiejar.update_from_response(set_cookie_headers)
                     self._set_cookies()
-            except ClientError as e:
+            except (ClientError, TimeoutError) as e:
                 raise ParseException("ttwid callback failed") from e
 
-        if not self.cookiejar.get(domain="iesdouyin.com").get("ttwid"):
+        if not self._has_ttwid():
             raise ParseException("ttwid register returned no cookie")
 
     async def parse_with_redirect(self, url: str) -> "ParseResult":
         """先重定向再解析，并更新 cookies"""
         logger.debug(f"[抖音] 短链重定向请求: {url}")
         async with self.session.get(
-            url, headers=self.ios_headers, allow_redirects=False, ssl=False
+            url, headers=self.ios_headers, allow_redirects=False
         ) as resp:
             logger.debug(f"[抖音] 短链重定向响应状态码: {resp.status}")
             # 从响应中提取 Set-Cookie 并更新
@@ -198,7 +200,7 @@ class DouyinParser(BaseParser):
         await self.ensure_ttwid()
         share_headers = self._sync_headers_for_url(url)
         async with self.session.get(
-            url, headers=share_headers, allow_redirects=False, ssl=False
+            url, headers=share_headers, allow_redirects=False
         ) as resp:
             if resp.status != 200:
                 raise ParseException(f"status: {resp.status}")
@@ -299,7 +301,6 @@ class DouyinParser(BaseParser):
                     play_url,
                     headers=headers,
                     allow_redirects=True,
-                    ssl=False,
                 ) as resp:
                     if resp.status >= 400:
                         logger.debug(
@@ -311,7 +312,7 @@ class DouyinParser(BaseParser):
                         logger.debug(f"[抖音] ratio={ratio} 未拿到有效文件大小")
                         continue
                     final_url = str(resp.url)
-            except ClientError as e:
+            except (ClientError, TimeoutError) as e:
                 logger.debug(f"[抖音] ratio={ratio} 探测请求失败: {e}")
                 continue
 
@@ -344,7 +345,7 @@ class DouyinParser(BaseParser):
         }
         logger.debug(f"[抖音] 请求参数: {params}")
         async with self.session.get(
-            url, params=params, headers=self.android_headers, ssl=False
+            url, params=params, headers=self.android_headers
         ) as resp:
             logger.debug(f"[抖音] 幻灯片API响应状态码: {resp.status}")
             resp.raise_for_status()

--- a/core/parsers/douyin/__init__.py
+++ b/core/parsers/douyin/__init__.py
@@ -1,7 +1,10 @@
 import re
-from typing import TYPE_CHECKING, ClassVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import urlparse
 
 import msgspec
+from aiohttp import ClientError
 
 from astrbot.api import logger
 
@@ -19,9 +22,20 @@ if TYPE_CHECKING:
     from ...data import ParseResult
 
 
+@dataclass(slots=True)
+class ProbedVideo:
+    url: str
+    size: int
+    headers: dict[str, str]
+
+
 class DouyinParser(BaseParser):
     # 平台信息
     platform: ClassVar[Platform] = Platform(name="douyin", display_name="抖音")
+    PLAY_RATIOS: ClassVar[tuple[str, ...]] = ("1080p", "720p", "540p", "360p")
+    TTWID_REGISTER_URL: ClassVar[str] = (
+        "https://ttwid.bytedance.com/ttwid/union/register/"
+    )
 
     def __init__(self, config: PluginConfig, downloader: Downloader):
         super().__init__(config, downloader)
@@ -36,6 +50,21 @@ class DouyinParser(BaseParser):
             self.ios_headers["Cookie"] = cookies_str
             self.android_headers["Cookie"] = cookies_str
 
+    def _sync_headers_for_url(self, url: str) -> dict[str, str]:
+        headers = self.ios_headers.copy()
+        headers.pop("Cookie", None)
+        if cookies_str := self.cookiejar.get_cookie_header_for_url(url):
+            headers["Cookie"] = cookies_str
+        elif self._is_iesdouyin_url(url):
+            if cookies_str := self.cookiejar.get_cookie_header(domain="iesdouyin.com"):
+                headers["Cookie"] = cookies_str
+        return headers
+
+    @staticmethod
+    def _is_iesdouyin_url(url: str) -> bool:
+        hostname = urlparse(url).hostname or ""
+        return hostname == "iesdouyin.com" or hostname.endswith(".iesdouyin.com")
+
     # https://v.douyin.com/_2ljF4AmKL8
     @handle("v.douyin", r"v\.douyin\.com/[a-zA-Z0-9_\-]+")
     @handle("jx.douyin", r"jx\.douyin\.com/[a-zA-Z0-9_\-]+")
@@ -45,6 +74,9 @@ class DouyinParser(BaseParser):
 
     # https://www.douyin.com/video/7521023890996514083
     # https://www.douyin.com/note/7469411074119322899
+    @handle("", r"(?<!\d)(?P<vid>\d{18,20})(?!\d)")
+    @handle("aweme_id", r"aweme_id[=:/\s]+(?P<vid>\d{10,})")
+    @handle("aweme", r"aweme/(?P<vid>\d{10,})")
     @handle("douyin", r"douyin\.com/(?P<ty>video|note)/(?P<vid>\d+)")
     @handle("iesdouyin", r"iesdouyin\.com/share/(?P<ty>slides|video|note)/(?P<vid>\d+)")
     @handle("m.douyin", r"m\.douyin\.com/share/(?P<ty>slides|video|note)/(?P<vid>\d+)")
@@ -54,33 +86,89 @@ class DouyinParser(BaseParser):
         r"jingxuan\.douyin.com/m/(?P<ty>slides|video|note)/(?P<vid>\d+)",
     )
     async def _parse_douyin(self, searched: re.Match[str]):
-        ty, vid = searched.group("ty"), searched.group("vid")
+        ty = searched.groupdict().get("ty") or "video"
+        vid = searched.group("vid")
         logger.debug(f"[抖音] 解析类型: {ty}, ID: {vid}")
         if ty == "slides":
             return await self.parse_slides(vid)
 
-        urls = (
-            self._build_m_douyin_url(ty, vid),
-            self._build_iesdouyin_url(ty, vid),
-        )
-        logger.debug(f"[抖音] 尝试解析URL列表: {urls}")
+        await self.ensure_ttwid()
+        share_url = self._build_iesdouyin_url(ty, vid)
+        logger.debug(f"[抖音] 使用 canonical share 页解析: {share_url}")
 
-        for url in urls:
-            try:
-                logger.debug(f"[抖音] 尝试解析: {url}")
-                return await self.parse_video(url)
-            except ParseException as e:
-                logger.warning(f"[抖音] 解析失败 {url}, 错误: {e}")
-                continue
-        raise ParseException("分享已删除或资源直链提取失败, 请稍后再试")
+        try:
+            return await self.parse_video(share_url)
+        except ParseException as e:
+            logger.warning(f"[抖音] canonical share 页解析失败 {share_url}, 错误: {e}")
+            raise ParseException("分享已删除或资源直链提取失败, 请稍后再试") from e
 
     @staticmethod
     def _build_iesdouyin_url(ty: str, vid: str) -> str:
-        return f"https://www.iesdouyin.com/share/{ty}/{vid}"
+        return f"https://www.iesdouyin.com/share/{ty}/{vid}/"
 
     @staticmethod
     def _build_m_douyin_url(ty: str, vid: str) -> str:
-        return f"https://m.douyin.com/share/{ty}/{vid}"
+        return f"https://m.douyin.com/share/{ty}/{vid}/"
+
+    async def ensure_ttwid(self) -> None:
+        if self.cookiejar.get(domain="iesdouyin.com").get("ttwid"):
+            return
+
+        logger.debug("[抖音] 当前缺少匿名 ttwid，尝试注册")
+        headers = self.ios_headers.copy()
+        headers.update(
+            {
+                "Content-Type": "application/json",
+                "Referer": "https://www.iesdouyin.com/",
+            }
+        )
+        payload = {
+            "region": "cn",
+            "aid": 1768,
+            "needFid": False,
+            "service": "www.iesdouyin.com",
+            "union": True,
+            "fid": "",
+        }
+        try:
+            async with self.session.post(
+                self.TTWID_REGISTER_URL,
+                json=payload,
+                headers=headers,
+                ssl=False,
+            ) as resp:
+                if resp.status >= 400:
+                    raise ParseException(f"ttwid register status: {resp.status}")
+                set_cookie_headers = resp.headers.getall("Set-Cookie", [])
+                self.cookiejar.update_from_response(set_cookie_headers)
+                self._set_cookies()
+                body = await resp.json(content_type=None)
+        except (ClientError, ValueError) as e:
+            raise ParseException("ttwid register failed") from e
+
+        if not isinstance(body, dict):
+            raise ParseException("ttwid register returned invalid body")
+
+        if callback_url := body.get("redirect_url"):
+            callback_headers = self._sync_headers_for_url(callback_url)
+            callback_headers["Referer"] = "https://www.iesdouyin.com/"
+            try:
+                async with self.session.get(
+                    callback_url,
+                    headers=callback_headers,
+                    allow_redirects=False,
+                    ssl=False,
+                ) as resp:
+                    if resp.status >= 400:
+                        raise ParseException(f"ttwid callback status: {resp.status}")
+                    set_cookie_headers = resp.headers.getall("Set-Cookie", [])
+                    self.cookiejar.update_from_response(set_cookie_headers)
+                    self._set_cookies()
+            except ClientError as e:
+                raise ParseException("ttwid callback failed") from e
+
+        if not self.cookiejar.get(domain="iesdouyin.com").get("ttwid"):
+            raise ParseException("ttwid register returned no cookie")
 
     async def parse_with_redirect(self, url: str) -> "ParseResult":
         """先重定向再解析，并更新 cookies"""
@@ -107,8 +195,10 @@ class DouyinParser(BaseParser):
         return await self.parse(keyword, searched)
 
     async def parse_video(self, url: str):
+        await self.ensure_ttwid()
+        share_headers = self._sync_headers_for_url(url)
         async with self.session.get(
-            url, headers=self.ios_headers, allow_redirects=False, ssl=False
+            url, headers=share_headers, allow_redirects=False, ssl=False
         ) as resp:
             if resp.status != 200:
                 raise ParseException(f"status: {resp.status}")
@@ -148,15 +238,29 @@ class DouyinParser(BaseParser):
             )
 
         # 添加视频内容
-        elif video_url := video_data.video_url:
+        elif video_data.video:
             cover_url = video_data.cover_url
             duration = video_data.video.duration if video_data.video else 0
             logger.debug(f"[抖音] 检测到视频内容，时长: {duration}秒")
-            contents.append(
-                self.create_video_content(
-                    video_url, cover_url, duration, headers=self.ios_headers
+            video_headers = self._build_media_headers(url)
+            video_url = None
+            if play_token := video_data.play_token:
+                try:
+                    probed = await self.probe_video_url(play_token, url)
+                    video_url = probed.url
+                    video_headers = probed.headers
+                    logger.debug(
+                        f"[抖音] play 端点探测成功，文件大小: {probed.size} 字节"
+                    )
+                except ParseException as e:
+                    logger.warning(f"[抖音] play 端点探测失败，回退 play_addr: {e}")
+            video_url = video_url or video_data.video_url
+            if video_url:
+                contents.append(
+                    self.create_video_content(
+                        video_url, cover_url, duration, headers=video_headers
+                    )
                 )
-            )
 
         # 构建作者
         author = self.create_author(
@@ -169,6 +273,68 @@ class DouyinParser(BaseParser):
             contents=contents,
             timestamp=video_data.create_time,
         )
+
+    @staticmethod
+    def _build_play_url(video_id: str, ratio: str) -> str:
+        return (
+            "https://aweme.snssdk.com/aweme/v1/play/"
+            f"?video_id={video_id}&ratio={ratio}"
+        )
+
+    def _build_media_headers(self, referer: str) -> dict[str, str]:
+        headers = self.ios_headers.copy()
+        headers.pop("Cookie", None)
+        headers["Referer"] = referer
+        return headers
+
+    async def probe_video_url(self, video_id: str, referer: str) -> ProbedVideo:
+        probed_by_size: dict[int, ProbedVideo] = {}
+
+        for ratio in self.PLAY_RATIOS:
+            play_url = self._build_play_url(video_id, ratio)
+            headers = self._build_media_headers(referer)
+            headers["Range"] = "bytes=0-1"
+            try:
+                async with self.session.get(
+                    play_url,
+                    headers=headers,
+                    allow_redirects=True,
+                    ssl=False,
+                ) as resp:
+                    if resp.status >= 400:
+                        logger.debug(
+                            f"[抖音] ratio={ratio} 探测失败，状态码: {resp.status}"
+                        )
+                        continue
+                    size = self._extract_response_size(resp.headers)
+                    if size <= 0:
+                        logger.debug(f"[抖音] ratio={ratio} 未拿到有效文件大小")
+                        continue
+                    final_url = str(resp.url)
+            except ClientError as e:
+                logger.debug(f"[抖音] ratio={ratio} 探测请求失败: {e}")
+                continue
+
+            probed_by_size.setdefault(
+                size, ProbedVideo(final_url, size, self._build_media_headers(referer))
+            )
+
+        if not probed_by_size:
+            raise ParseException("can't probe play endpoint")
+
+        return max(probed_by_size.values(), key=lambda item: item.size)
+
+    @staticmethod
+    def _extract_response_size(headers) -> int:
+        if content_range := headers.get("Content-Range"):
+            if matched := re.search(r"/(\d+)\s*$", content_range):
+                return int(matched.group(1))
+        if content_length := headers.get("Content-Length"):
+            try:
+                return int(content_length)
+            except ValueError:
+                return 0
+        return 0
 
     async def parse_slides(self, video_id: str):
         url = "https://www.iesdouyin.com/web/api/v2/aweme/slidesinfo/"

--- a/core/parsers/douyin/video.py
+++ b/core/parsers/douyin/video.py
@@ -1,5 +1,6 @@
 from random import choice
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 from msgspec import Struct, field
 
@@ -17,7 +18,8 @@ class Author(Struct):
 
 
 class PlayAddr(Struct):
-    url_list: list[str]
+    uri: str | None = None
+    url_list: list[str] = field(default_factory=list)
 
 
 class Cover(Struct):
@@ -48,7 +50,24 @@ class VideoData(Struct):
 
     @property
     def video_url(self) -> str | None:
-        return choice(self.video.play_addr.url_list).replace("playwm", "play") if self.video else None
+        if not self.video or not self.video.play_addr.url_list:
+            return None
+        return choice(self.video.play_addr.url_list).replace("playwm", "play")
+
+    @property
+    def play_token(self) -> str | None:
+        if not self.video:
+            return None
+
+        play_addr = self.video.play_addr
+        if play_addr.uri:
+            return play_addr.uri
+
+        for url in play_addr.url_list:
+            query = parse_qs(urlparse(url).query)
+            if video_id := query.get("video_id"):
+                return video_id[0]
+        return None
 
     @property
     def cover_url(self) -> str | None:

--- a/core/sender.py
+++ b/core/sender.py
@@ -57,7 +57,19 @@ class MessageSender:
     def _to_file_uri(self, path: Path) -> str:
         if not path.is_absolute():
             path = path.resolve()
-        return f"file:///{path}"
+        return path.as_uri()
+
+    @staticmethod
+    def _image_from_path(path: Path) -> Image:
+        return Image.fromFileSystem(str(path))
+
+    @staticmethod
+    def _video_from_path(path: Path) -> Video:
+        return Video.fromFileSystem(str(path))
+
+    @staticmethod
+    def _record_from_path(path: Path) -> Record:
+        return Record.fromFileSystem(str(path))
 
     @staticmethod
     def _iter_contents(result: ParseResult):
@@ -130,7 +142,7 @@ class MessageSender:
             return
 
         if image_path := await self.renderer.render_card(result):
-            await event.send(event.chain_result([Image(self._to_file_uri(image_path))]))
+            await event.send(event.chain_result([self._image_from_path(image_path)]))
 
     async def _build_segments(
         self,
@@ -149,7 +161,7 @@ class MessageSender:
         # 合并转发时，卡片以内联形式作为一个消息段参与合并
         if plan["render_card"] and plan["force_merge"]:
             if image_path := await self.renderer.render_card(result):
-                segs.append(Image(self._to_file_uri(image_path)))
+                segs.append(self._image_from_path(image_path))
 
         # 轻媒体处理
         for cont in plan["light"]:
@@ -169,10 +181,9 @@ class MessageSender:
 
             match cont:
                 case ImageContent():
-                    segs.append(Image(self._to_file_uri(path)))
+                    segs.append(self._image_from_path(path))
                 case GraphicsContent() as g:
-                    # OneBot/aiocqhttp 本地文件参数要求 file:// URI，而非裸本地路径。
-                    segs.append(Image(self._to_file_uri(path)))
+                    segs.append(self._image_from_path(path))
                     # GraphicsContent 允许携带补充文本
                     if g.text:
                         segs.append(Plain(g.text))
@@ -193,12 +204,12 @@ class MessageSender:
 
             match cont:
                 case VideoContent() | DynamicContent():
-                    segs.append(Video(self._to_file_uri(path)))
+                    segs.append(self._video_from_path(path))
                 case AudioContent():
                     segs.append(
                         File(name=path.name, file=self._to_file_uri(path))
                         if self.cfg.audio_to_file
-                        else Record(self._to_file_uri(path))
+                        else self._record_from_path(path)
                     )
                 case FileContent():
                     segs.append(File(name=path.name, file=self._to_file_uri(path)))

--- a/core/sender.py
+++ b/core/sender.py
@@ -57,7 +57,7 @@ class MessageSender:
     def _to_file_uri(self, path: Path) -> str:
         if not path.is_absolute():
             path = path.resolve()
-        return path.as_uri()
+        return f"file:///{path}"
 
     @staticmethod
     def _iter_contents(result: ParseResult):


### PR DESCRIPTION
## 主要改动

  - 新增抖音 canonical share 页解析流程，支持：
    - `v.douyin.com` 短链
    - `douyin.com/video/<id>` 长链
    - 裸 `aweme_id`
  - 通过匿名 `ttwid` 访问抖音 share 页，解析 SSR HTML 内嵌的 `window._ROUTER_DATA`。
  - 从 `video.play_addr.uri` 提取 video token，拼接 `aweme.snssdk.com/aweme/v1/play/` 下载链路。
  - 增加 `1080p / 720p / 540p / 360p` ratio 阶梯探测，并按 `content-length` 去重真实画质档。
  - 探测 CDN 时使用 ranged GET，避免 HEAD 请求不稳定。
  - 保留旧 `video_url` 回退逻辑，探测失败时不影响原解析链路。
  - 移除默认 `ssl=False`，避免关闭 TLS 校验。
  - 补充 `TimeoutError` 捕获，避免 ttwid 注册、回调、画质探测超时导致整个解析崩溃。
  - 修复 AstrBot 25.3版本本地媒体发送问题，使用 AstrBot `fromFileSystem(str(path))` 构造图片、视频、语音组件，避免 `Path` 对象触发 Pydantic 校验失败。
  
  
<img width="3429" height="1836" alt="57851795b320b68da1b50956ce65adb8" src="https://github.com/user-attachments/assets/10cab4dd-8182-4d0f-b457-b96cec64daef" />
<img width="2206" height="493" alt="image" src="https://github.com/user-attachments/assets/162e3dab-c1fe-406e-804d-cec772ef25ec" />

## Summary by Sourcery

基于 SSR 为抖音链接新增规范分享页解析能力，并提升远程与本地媒体投递的稳定性与鲁棒性。

New Features:
- 支持通过 SSR 解析抖音规范分享页，包括短链接、长视频/笔记 URL，以及裸 aweme ID。
- 从 SSR 路由数据中推导播放端点，并探测多种清晰度比例以选择稳定的直链视频 URL。

Bug Fixes:
- 修复 AstrBot 25.3 中本地媒体发送失败的问题：改为从文件系统路径构造图片、视频和语音片段，而不是使用 Path 对象。
- 移除默认的 `ssl=False` 标志，避免在抖音请求中禁用 TLS 校验。

Enhancements:
- 引入匿名 ttwid 注册和回调处理机制，以更可靠地访问抖音分享页。
- 使用带范围（Range）的 GET 请求配合基于大小的去重，探测 CDN 视频的不同清晰度并选择可用性最佳的流。
- 为抖音请求增加超时处理以及 Cookie/请求头同步，防止在网络异常时解析器崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add SSR-based canonical share page parsing for Douyin links and improve media delivery robustness for both remote and local content.

New Features:
- Support parsing Douyin canonical share pages via SSR, including short links, long video/note URLs, and bare aweme IDs.
- Derive play endpoints from SSR router data and probe multiple quality ratios to select a stable direct video URL.

Bug Fixes:
- Fix local media sending failures in AstrBot 25.3 by constructing image, video, and voice segments from filesystem paths instead of Path objects.
- Avoid TLS verification being disabled on Douyin requests by removing the default ssl=False flag.

Enhancements:
- Introduce anonymous ttwid registration and callback handling to access Douyin share pages more reliably.
- Use ranged GET requests with size-based deduplication to probe CDN video qualities and pick the best available stream.
- Add timeout handling and cookie/header synchronization for Douyin requests to prevent parser crashes under network issues.

</details>