### PR TITLE
fix: 处理函数 on_message 时出现异常：'NoneType' object has no attribute 'value'

### DIFF
--- a/core/parsers/bilibili/__init__.py
+++ b/core/parsers/bilibili/__init__.py
@@ -429,6 +429,8 @@ class BilibiliParser(BaseParser):
                 no_dolby_video=True,
                 no_hdr=True,
             )
+        if not streams:
+            raise DownloadException("未找到可下载的视频流")
         video_stream = streams[0]
         if not isinstance(video_stream, VideoStreamDownloadURL):
             raise DownloadException("未找到可下载的视频流")

--- a/core/parsers/bilibili/__init__.py
+++ b/core/parsers/bilibili/__init__.py
@@ -144,11 +144,11 @@ class BilibiliParser(BaseParser):
         from .video import AIConclusion, VideoInfo
 
         video = await self._get_video(bvid=bvid, avid=avid)
-        # 转换为 msgspec struct
         video_info = convert(await video.get_info(), VideoInfo)
-        # 获取简介
+        if not video_info.owner:
+            raise ParseException("未获取到 UP 主信息，请求可能被风控")
+
         text = f"简介: {video_info.desc}" if video_info.desc else None
-        # up
         author = self.create_author(video_info.owner.name, video_info.owner.face)
         # 处理分 p
         page_info = video_info.extract_info_with_page(page_num)
@@ -412,15 +412,23 @@ class BilibiliParser(BaseParser):
         if video is None:
             video = await self._get_video(bvid=bvid, avid=avid)
 
-        # 获取下载数据
         download_url_data = await video.get_download_url(page_index=page_index)
         detecter = VideoDownloadURLDataDetecter(download_url_data)
-        streams = detecter.detect_best_streams(
-            video_max_quality=self.video_quality,
-            codecs=self.video_codecs,
-            no_dolby_video=True,
-            no_hdr=True,
-        )
+        try:
+            streams = detecter.detect_best_streams(
+                video_max_quality=self.video_quality,
+                codecs=self.video_codecs,
+                no_dolby_video=True,
+                no_hdr=True,
+            )
+        except (AttributeError, IndexError) as e:
+            logger.warning(f"detect_best_streams 异常 ({e})，降级重试")
+            streams = detecter.detect_best_streams(
+                video_max_quality=self.video_quality,
+                codecs=[],
+                no_dolby_video=True,
+                no_hdr=True,
+            )
         video_stream = streams[0]
         if not isinstance(video_stream, VideoStreamDownloadURL):
             raise DownloadException("未找到可下载的视频流")

--- a/core/parsers/bilibili/video.py
+++ b/core/parsers/bilibili/video.py
@@ -42,18 +42,18 @@ class PageInfo:
     cover: str | None = None
 
 
-class VideoInfo(Struct):
+class VideoInfo(Struct, kw_only=True):
     bvid: str
     """bvid"""
     title: str
     """标题"""
-    desc: str
+    desc: str | None = None
     """简介"""
     duration: int
     """时长"""
-    owner: Upper
+    owner: Upper | None = None
     """作者信息"""
-    stat: Stats
+    stat: Stats | None = None
     """统计信息"""
     pubdate: int
     """公开时间戳"""
@@ -72,10 +72,8 @@ class VideoInfo(Struct):
 
     @property
     def formatted_stats_info(self) -> str:
-        """
-        格式化视频信息
-        """
-        # 定义需要展示的数据及其显示名称
+        if not self.stat:
+            return ""
         stats_mapping = [
             ("👍", self.stat.like),
             ("🪙", self.stat.coin),

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ tqdm>=4.67.1,<5.0.0
 curl_cffi>=0.13.0,<1.0.0,!=0.14.0
 msgspec>=0.20.0,<1.0.0
 apilmoji[tqdm]>=0.3.0,<1.0.0
-bilibili-api-python>=17.4.1,<18.0.0
+bilibili-api-python @ git+https://github.com/Nemo2011/bilibili-api@dev
 yt-dlp[default]>=2025.12.8
 gallery-dl>=1.31.2
-


### PR DESCRIPTION
### 改动总结
#### 1. core/parsers/bilibili/video.py

VideoInfo Struct 字段 Optional 化 + kw_only=True
```
class VideoInfo(Struct, kw_only=True):       # ← 新增 kw_only=True
    bvid: str
    title: str
    desc: str | None = None                  # str → str | None
    duration: int
    owner: Upper | None = None               # Upper → Upper | None
    stat: Stats | None = None                # Stats → Stats | None
    pubdate: int
    ctime: int
    pic: str | None = None
    pages: list[Page] | None = None
```
formatted_stats_info 加守卫 (video.py:73-76)
```
@property
def formatted_stats_info(self) -> str:
    if not self.stat:          # ← 新增
        return ""              # ← 新增
```

#### 2. core/parsers/bilibili/__init__.py

parse_video 加 owner 守卫 (__init__.py:148-149)
```
if not video_info.owner:
    raise ParseException("未获取到 UP 主信息，请求可能被风控")
```
extract_download_urls 降级容错 (__init__.py:417-431)
```
try:
    streams = detecter.detect_best_streams(
        video_max_quality=self.video_quality,
        codecs=self.video_codecs,
        no_dolby_video=True, no_hdr=True,
    )
except (AttributeError, IndexError) as e:
    logger.warning(f"detect_best_streams 异常 ({e})，降级重试")
    streams = detecter.detect_best_streams(
        video_max_quality=self.video_quality,
        codecs=[],                            # ← 不限制编码，避开 codec 排序崩溃
        no_dolby_video=True, no_hdr=True,
    )
```

#### 3. requirements.txt
上游dev分支修复
```
bilibili-api-python @ git+https://github.com/Nemo2011/bilibili-api@dev
```

## Summary by Sourcery

加固 Bilibili 视频解析与下载逻辑，以应对缺失元数据及上游 API 问题。

Bug 修复：
- 当 Bilibili 视频的作者信息缺失时，通过将 `owner` 视为可选并抛出解析错误，防止程序崩溃。
- 当视频统计信息缺失时，将统计信息设为可选，并在生成格式化统计数据前进行短路判断，以避免属性错误。
- 当由于上游数据问题导致基于编码格式的最佳下载流检测失败时，增加备用路径用于检测最佳下载流。

增强：
- 将 Bilibili `VideoInfo` 字段改为仅支持关键字参数（keyword-only），并允许 `description`、`owner`、`stats`、`cover` 和 `pages` 为可选，以更好地贴合上游 API 的返回数据。

构建：
- 将 `bilibili-api-python` 依赖指向上游的开发分支（dev branch），以引入最新修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden Bilibili video parsing and downloading against missing metadata and upstream API issues.

Bug Fixes:
- Prevent crashes when Bilibili video owner information is missing by treating owner as optional and raising a parse error.
- Avoid attribute errors when video statistics are absent by making stats optional and short-circuiting formatted stats generation.
- Add a fallback path for detecting best download streams when codec-based detection fails due to upstream data issues.

Enhancements:
- Make Bilibili VideoInfo fields keyword-only and allow optional description, owner, stats, cover, and pages to better reflect upstream API responses.

Build:
- Point bilibili-api-python dependency to the upstream dev branch to incorporate latest fixes.

</details>