### PR TITLE
fix: Improve file URI generation for POSIX paths

### DIFF
--- a/core/sender.py
+++ b/core/sender.py
@@ -57,6 +57,9 @@ class MessageSender:
     def _to_file_uri(self, path: Path) -> str:
         if not path.is_absolute():
             path = path.resolve()
+        posix_path = path.as_posix()
+        if posix_path.startswith("/"):
+            return f"file:////{posix_path.lstrip('/')}"
         return path.as_uri()
 
     @staticmethod

--- a/core/sender.py
+++ b/core/sender.py
@@ -57,9 +57,11 @@ class MessageSender:
     def _to_file_uri(self, path: Path) -> str:
         if not path.is_absolute():
             path = path.resolve()
-        posix_path = path.as_posix()
-        if posix_path.startswith("/"):
-            return f"file:////{posix_path.lstrip('/')}"
+        # Windows: Path.as_uri() → file:///C:/path, [8:] → C:/path ✓
+        # POSIX:  Path.as_uri() → file:///path,     [8:] → path    ✗ (丢失前导 /)
+        # 补偿：POSIX 绝对路径追加一个 /, 使 [8:] → /path ✓
+        if not path.drive:
+            return f"file:////{path.as_posix().lstrip('/')}"
         return path.as_uri()
 
     @staticmethod


### PR DESCRIPTION
Reverts Zhalslar/astrbot_plugin_parser#127

ncm.py 因 路径问题 导致语音无法发出

Fix handling of POSIX absolute paths in _to_file_uri method.

The _to_file_uri method in core/sender.py now correctly handles both Windows and POSIX absolute paths by ensuring that the leading slash is preserved after path URI conversion.