### PR TITLE
修复 B站视频解析时因视频流 codecs 字段为空导致 detect_best_streams 排序报 NoneType 错误的问题

### DIFF
--- a/core/parsers/bilibili/__init__.py
+++ b/core/parsers/bilibili/__init__.py
@@ -388,56 +388,57 @@ class BilibiliParser(BaseParser):
             raise ParseException("avid 和 bvid 至少指定一项")
 
     async def extract_download_urls(
-        self,
-        video: Video | None = None,
-        *,
-        bvid: str | None = None,
-        avid: int | None = None,
-        page_index: int = 0,
-    ) -> tuple[str, str | None]:
-        """解析视频下载链接
+            self,
+            video: Video | None = None,
+            *,
+            bvid: str | None = None,
+            avid: int | None = None,
+            page_index: int = 0,
+        ) -> tuple[str, str | None]:
+            """解析视频下载链接
 
-        Args:
-            bvid (str | None): bvid
-            avid (int | None): avid
-            page_index (int): 页索引 = 页码 - 1
-        """
+            Args:
+                bvid (str | None): bvid
+                avid (int | None): avid
+                page_index (int): 页索引 = 页码 - 1
+            """
 
-        from bilibili_api.video import (
-            AudioStreamDownloadURL,
-            VideoDownloadURLDataDetecter,
-            VideoStreamDownloadURL,
-        )
+            from bilibili_api.video import (
+                AudioStreamDownloadURL,
+                VideoDownloadURLDataDetecter,
+                VideoStreamDownloadURL,
+            )
 
-        if video is None:
-            video = await self._get_video(bvid=bvid, avid=avid)
+            if video is None:
+                video = await self._get_video(bvid=bvid, avid=avid)
 
-        # 获取下载数据
-        download_url_data = await video.get_download_url(page_index=page_index)
-        # Normalize hvc1 streams so bilibili-api can recognize them as HEV.
-        for video_data in download_url_data.get("dash", {}).get("video", []):
-            codecs = video_data.get("codecs", "")
-            if isinstance(codecs, str) and codecs.startswith("hvc1"):
-                video_data["codecs"] = f"hev,{codecs}"
-        detecter = VideoDownloadURLDataDetecter(download_url_data)
-        streams = detecter.detect_best_streams(
-            video_max_quality=self.video_quality,
-            codecs=self.video_codecs,
-            no_dolby_video=True,
-            no_hdr=True,
-        )
-        video_stream = streams[0]
-        if not isinstance(video_stream, VideoStreamDownloadURL):
-            raise DownloadException("未找到可下载的视频流")
-        logger.debug(
-            f"视频流质量: {video_stream.video_quality.name}, 编码: {video_stream.video_codecs}"
-        )
+            # 获取下载数据
+            download_url_data = await video.get_download_url(page_index=page_index)
+            # Normalize hvc1 streams so bilibili-api can recognize them as HEV.
+            for video_data in download_url_data.get("dash", {}).get("video", []):
+                codecs = video_data.get("codecs", "")
+                if isinstance(codecs, str) and codecs.startswith("hvc1"):
+                    video_data["codecs"] = f"hev,{codecs}"
+                # ========== 新增修复：确保 codecs 字段不为空 ==========
+                if not video_data.get("codecs"):
+                    video_data["codecs"] = "avc1"   # 默认编码，避免后续比较时报 NoneType 错误
 
-        audio_stream = streams[1]
-        if not isinstance(audio_stream, AudioStreamDownloadURL):
-            return video_stream.url, None
-        logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
-        return video_stream.url, audio_stream.url
+            detecter = VideoDownloadURLDataDetecter(download_url_data)
+            streams = detecter.detect_best_streams(
+                video_max_quality=self.video_quality,
+                codecs=self.video_codecs,
+                no_dolby_video=True,
+                no_hdr=True,
+            )
+            video_stream = streams[0]
+            if not isinstance(video_stream, VideoStreamDownloadURL):
+                raise DownloadException("未找到可下载的视频流")
+            logger.debug(
+                f"视频流质量: {video_stream.video_quality.name}, 编码: {video_stream.video_codecs}"
+            )
 
-
-
+            audio_stream = streams[1]
+            if not isinstance(audio_stream, AudioStreamDownloadURL):
+                return video_stream.url, None
+            logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
+            return video_stream.url, audio_stream.url


### PR DESCRIPTION
# 终端显示报错

[18:43:50.612] [Core] [INFO] [core.event_bus:61]: [default] [红叶(aiocqhttp)] i12cu2/631061931: https://b23.tv/gUySqzV
[18:43:53.056] [Core] [ERRO] [v4.20.0] [method.star_request:52]: Traceback (most recent call last):
  File "C:\Users\Admin\AppData\Roaming\uv\tools\astrbot\Lib\site-packages\astrbot\core\pipeline\process_stage\method\star_request.py", line 47, in process
    async for ret in wrapper:
  File "C:\Users\Admin\AppData\Roaming\uv\tools\astrbot\Lib\site-packages\astrbot\core\pipeline\context_utils.py", line 67, in call_handler
    ret = await ready_to_call
          ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\data\plugins\astrbot_plugin_parser\main.py", line 197, in on_message
    await self.sender.send_parse_result(event, parse_res)
  File "C:\Users\Admin\data\plugins\astrbot_plugin_parser\core\sender.py", line 317, in send_parse_result
    sent = await self._send_group(event, result, group) or sent
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\data\plugins\astrbot_plugin_parser\core\sender.py", line 268, in _send_group
    segs = await self._build_segments(result, plan)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\data\plugins\astrbot_plugin_parser\core\sender.py", line 188, in _build_segments
    path: Path = await cont.get_path()
                 ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\data\plugins\astrbot_plugin_parser\core\data.py", line 23, in get_path
    self.path_task = await self.path_task
                     ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\data\plugins\astrbot_plugin_parser\core\parsers\bilibili\__init__.py", line 173, in download_video
    v_url, a_url = await self.extract_download_urls(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\data\plugins\astrbot_plugin_parser\core\parsers\bilibili\__init__.py", line 416, in extract_download_urls
    streams = detecter.detect_best_streams(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Admin\AppData\Roaming\uv\tools\astrbot\Lib\site-packages\bilibili_api\video.py", line 2602, in detect_best_streams
    video_streams.sort(key=cmp_to_key(video_stream_cmp), reverse=True)
  File "C:\Users\Admin\AppData\Roaming\uv\tools\astrbot\Lib\site-packages\bilibili_api\video.py", line 2584, in video_stream_cmp
    elif s1.video_codecs.value != s2.video_codecs.value:
         ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'value'

[18:43:53.056] [Core] [ERRO] [v4.20.0] [method.star_request:53]: Star data.plugins.astrbot_plugin_parser.main_on_message handle error: 'NoneType' object has no attribute 'value'
[18:43:53.056] [Core] [INFO] [astrbot_plugin_zhihusummary.main:88]: [zhihuSummary/DBG] [AccessCheck] mode=blacklist, origin=红叶:GroupMessage:1076261294
[18:43:53.057] [Core] [INFO] [respond.stage:184]: Prepare to send - i12cu2/631061931:
[18:43:53.057] [Core] [INFO] [pipeline.context_utils:103]: astrbot - after_message_sent 终止了事件传播。

# 问题分析 

这个报错是 astrbot_plugin_parser 插件在处理B站视频链接时，调用底层的 bilibili_api 库引发的。核心问题是视频流信息不完整，导致库在比较编码格式时遇到了空值（None）。

# 解决方法

```
for video_data in download_url_data.get("dash", {}).get("video", []):
    codecs = video_data.get("codecs", "")
    if isinstance(codecs, str) and codecs.startswith("hvc1"):
        video_data["codecs"] = f"hev,{codecs}"
```
修改为
```
for video_data in download_url_data.get("dash", {}).get("video", []):
    codecs = video_data.get("codecs", "")
    if isinstance(codecs, str) and codecs.startswith("hvc1"):
        video_data["codecs"] = f"hev,{codecs}"
    # 新增修复：缺失 codecs 时补默认值
    if not video_data.get("codecs"):
        video_data["codecs"] = "avc1"
```

经测试已修复该问题

总结

fix(video): 修复video_codecs为None时排序报错 望merge

## Summary by Sourcery

Bug Fixes:
- 确保对没有 `codecs` 字段的 DASH 视频流条目分配默认编解码器值，从而避免在 `bilibili_api` 流排序过程中出现 `NoneType` 错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure DASH video stream entries without a codecs field are assigned a default codec value to avoid NoneType errors in bilibili_api stream sorting.

</details>