### PR TITLE
fix(parser/iwara): 修复iwara解析器的路由匹配规则

### DIFF
--- a/core/parsers/iwara.py
+++ b/core/parsers/iwara.py
@@ -171,7 +171,7 @@ class IwaraParser(BaseParser):
         api.cookie = self.mycfg.cookies if self.mycfg.cookies else ""
         api.proxy = self.proxy
         
-    @handle("iwara.tv", r"iwara\.tv/video/(?P<video_id>\w+)")
+    @handle("iwara.tv/video", r"iwara\.tv/video/(?P<video_id>\w+)")
     async def _parse(self, searched: Match[str]) -> ParseResult:
         video_id = searched.group("video_id")
         video_info = await api.iwaraID_Get_videoInfo(video_id)
@@ -232,7 +232,7 @@ class IwaraParser(BaseParser):
             url=f"https://www.iwara.tv/video/{video_id}"
         )
     
-    @handle("iwara.tv", r"iwara\.tv/image/(?P<image_id>\w+)")
+    @handle("iwara.tv/image", r"iwara\.tv/image/(?P<image_id>\w+)")
     async def _parse_image(self, searched: Match[str]) -> ParseResult:
         image_id = searched.group("image_id")
         image_info = await api.IMG_iwaraID_Get_imageInfo(image_id)


### PR DESCRIPTION
## 测试
现在没有任何问题了
<img width="1928" height="735" alt="image" src="https://github.com/user-attachments/assets/005f4a31-4235-4729-b954-1ec1967f9ce2" />
<img width="1924" height="863" alt="image" src="https://github.com/user-attachments/assets/2064d865-7127-4236-819d-12496ce1edbb" />


## Summary by Sourcery

调整 iwara 解析器的路由，以正确匹配视频和图片 URL。

Bug Fixes:
- 通过更新已注册的路由模式，修复 iwara 视频 URL 处理程序的路由问题。
- 通过更新已注册的路由模式，修复 iwara 图片 URL 处理程序的路由问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust iwara parser routing to correctly match video and image URLs.

Bug Fixes:
- Fix iwara video URL handler routing by updating the registered route pattern.
- Fix iwara image URL handler routing by updating the registered route pattern.

</details>