### PR TITLE
fix(twitter): 支持 twitter.com 域名与更多链接形式，并默认启用推特解析

### DIFF
--- a/core/parsers/twitter.py
+++ b/core/parsers/twitter.py
@@ -43,10 +43,13 @@ class TwitterParser(BaseParser):
                 raise ClientError(f"xdown API {resp.status} {resp.reason}")
             return await resp.json()
 
-    @handle("x.com", r"https?://x.com/[0-9-a-zA-Z_]{1,20}/status/([0-9]+)")
+    # https://x.com/jack/status/20 ; https://twitter.com/jack/status/20
+    # 兼容 twitter.com/mobile./www. 前缀、/i/web/status/ 等路径，以及无协议头链接
+    @handle("x.com", r"x\.com/(?:[A-Za-z0-9_]+/)*status/\d+")
+    @handle("twitter.com", r"twitter\.com/(?:[A-Za-z0-9_]+/)*status/\d+")
     async def _parse(self, searched: re.Match[str]) -> ParseResult:
-        # 从匹配对象中获取原始URL
-        url = searched.group(0)
+        # 从匹配对象中获取原始URL（补全协议头）
+        url = f"https://{searched.group(0)}"
         resp = await self._req_xdown_api(url)
         if resp.get("status") != "ok":
             raise ParseException("解析失败")

--- a/default_template.json
+++ b/default_template.json
@@ -38,5 +38,11 @@
     "cookies": "",
     "show_body_text": true,
     "video_send_mode": "first"
+  },
+  {
+    "__template_key": "twitter",
+    "enable": true,
+    "use_proxy": false,
+    "cookies": ""
   }
 ]


### PR DESCRIPTION
修复 issues 中反馈的 Twitter/X 解析问题，共两点：

### 1. TwitterParser 有实现但默认不生效
`TwitterParser` 与 `ParserConfig.twitter` 都在，但 `default_template.json`
未包含 `twitter`，而注册逻辑严格按 `enabled_platforms()` 过滤 → 默认环境下
推特解析形同不存在。本 PR 将 `twitter` 加入默认模板。

### 2. 正则覆盖不足
原规则 `https?://x.com/{user}/status/{id}` 仅匹配 `x.com` 且要求协议头，漏掉：
- `twitter.com` / `mobile.twitter.com`（大量链接仍是该域名）
- `x.com/i/web/status/...` 等多段路径
- 无 `http` 前缀的链接

改为同时匹配 `x.com` 与 `twitter.com`，放宽中间路径段，并在处理端统一补全
`https://`（`xdown.app` 接口对以上形式均可正常解析，已验证）。

改动文件：`core/parsers/twitter.py`、`default_template.json`

## Summary by Sourcery

通过更新默认配置并拓展支持的 URL 模式，启用并修正 Twitter/X 链接解析。

Bug 修复：
- 通过在默认模板配置中加入 Twitter 解析器，修复 Twitter/X 解析未默认启用的问题。
- 修复 Twitter/X URL 匹配，使来自 twitter.com、移动子域、替代路径格式以及缺少显式协议的链接都能被正确解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable and correct Twitter/X link parsing by updating the default configuration and broadening supported URL patterns.

Bug Fixes:
- Fix Twitter/X parsing not being active by default by including the twitter parser in the default template configuration.
- Fix Twitter/X URL matching so that links from twitter.com, mobile subdomains, alternative path formats, and links without an explicit protocol are correctly parsed.

</details>