### PR TITLE
fix(bilibili): 无匹配视频流时优雅报错，避免 IndexError 中断解析

### DIFF
--- a/core/parsers/bilibili/__init__.py
+++ b/core/parsers/bilibili/__init__.py
@@ -426,6 +426,8 @@ class BilibiliParser(BaseParser):
             no_dolby_video=True,
             no_hdr=True,
         )
+        if not streams:
+            raise DownloadException("未找到可下载的视频流（可能是所选编码无对应流）")
         video_stream = streams[0]
         if not isinstance(video_stream, VideoStreamDownloadURL):
             raise DownloadException("未找到可下载的视频流")
@@ -433,7 +435,7 @@ class BilibiliParser(BaseParser):
             f"视频流质量: {video_stream.video_quality.name}, 编码: {video_stream.video_codecs}"
         )
 
-        audio_stream = streams[1]
+        audio_stream = streams[1] if len(streams) > 1 else None
         if not isinstance(audio_stream, AudioStreamDownloadURL):
             return video_stream.url, None
         logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")


### PR DESCRIPTION
修复 issues 中反馈的 Bilibili 解析偶发崩溃。

`VideoDownloadURLDataDetecter.detect_best_streams()` 在所选编码/画质无对应流时
可能返回空列表，原代码直接 `streams[0]` / `streams[1]` 取值会抛 `IndexError`，
打断整条发送链路（且异常直接冒泡到 AstrBot core）。

本 PR：
- `streams` 为空时抛出可读的 `DownloadException`；
- 取音频流前先判断长度（`streams[1] if len(streams) > 1 else None`）。

改动文件：`core/parsers/bilibili/__init__.py`（+3 −1）

## Summary by Sourcery

在提取下载链接时，更加优雅地处理缺失的 Bilibili 视频/音频流，避免程序崩溃。

Bug Fixes:
- 当未返回匹配的 Bilibili 视频流时，抛出可读的 `DownloadException`，从而防止因 `IndexError` 导致的崩溃。
- 不再默认认为一定存在第二条音频流，而是在检测到的音频流列表长度大于 1 时才选择第二条音频流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing Bilibili video/audio streams more gracefully during download URL extraction to avoid crashes.

Bug Fixes:
- Prevent IndexError crashes by throwing a readable DownloadException when no matching Bilibili video streams are returned.
- Avoid assuming a second audio stream exists by only selecting it when the detected stream list has more than one entry.

</details>