### PR TITLE
fix: 修复小红书链接变更

### DIFF
--- a/core/parsers/xhs.py
+++ b/core/parsers/xhs.py
@@ -43,6 +43,7 @@ class XHSParser(BaseParser):
             self.ios_headers["cookie"] = self.cookiejar.cookies_str
 
     @handle("xhslink.com", r"xhslink\.com/[A-Za-z0-9._?%&+=/#@-]+")
+    @handle("xhslink.cn", r"xhslink\.cn/[A-Za-z0-9._?%&+=/#@-]+")
     async def _parse_short_link(self, searched: re.Match[str]):
         url = f"https://{searched.group(0)}"
         return await self.parse_with_redirect(url, self.ios_headers)


### PR DESCRIPTION
旧链接仍然可以正常解析和使用，新复制链接采用变更
#161

## Summary by Sourcery

支持解析更新后的小红书短链域名，并与现有域名保持兼容。

New Features:
- 添加对 `xhslink.cn` 短链域名的处理，以便解析新的复制链接。

Bug Fixes:
- 确保使用新 `xhslink.cn` 域名的小红书链接能够正确解析并完成跳转，而不是解析失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support parsing of updated Xiaohongshu short-link domain alongside the existing one.

New Features:
- Add handling for the xhslink.cn short-link domain so new copied links can be parsed.

Bug Fixes:
- Ensure Xiaohongshu links using the new xhslink.cn domain are correctly resolved instead of failing to parse.

</details>