### PR TITLE
Fix bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 更新日志
 
+## v1.5.5
+
+Bug Fixes:
+
+- 当未安装 `curl_cffi` 时，为 Bilibili 解析器的初始化添加保护，并给出明确的错误提示。
+- 当来源提供字符串或浮点数值时，将 Bilibili 的 dynamic 和 opus 发表时间戳字段规范化为整数。
+
 ## v1.5.4
 
 - 新增 pixiv 解析器

--- a/core/parsers/bilibili/__init__.py
+++ b/core/parsers/bilibili/__init__.py
@@ -20,11 +20,13 @@ from ..base import (
 )
 from .login import BilibiliLogin
 
-# 选择客户端
-select_client("curl_cffi")
-# 模拟浏览器，第二参数数值参考 curl_cffi 文档
-# https://curl-cffi.readthedocs.io/en/latest/impersonate.html
-request_settings.set("impersonate", "chrome131")
+try:
+    select_client("curl_cffi")
+    request_settings.set("impersonate", "chrome131")
+except Exception as e:
+    raise ModuleNotFoundError(
+        f"curl_cffi is required by bilibili parser but not installed: {e}"
+    ) from e
 
 
 class BilibiliParser(BaseParser):

--- a/core/parsers/bilibili/dynamic.py
+++ b/core/parsers/bilibili/dynamic.py
@@ -10,7 +10,7 @@ class AuthorInfo(Struct):
     face: str
     mid: int
     pub_time: str
-    pub_ts: int
+    pub_ts: str | int | float
     # jump_url: str
     # following: bool = False
     # official_verify: dict[str, Any] | None = None
@@ -120,7 +120,7 @@ class DynamicModule(Struct):
     @property
     def pub_ts(self) -> int:
         """获取发布时间戳"""
-        return self.module_author.pub_ts
+        return int(float(self.module_author.pub_ts))
 
     @property
     def major_info(self) -> dict[str, Any] | None:
@@ -152,7 +152,7 @@ class DynamicInfo(Struct):
     @property
     def timestamp(self) -> int:
         """获取发布时间戳"""
-        return self.modules.pub_ts
+        return int(float(self.modules.pub_ts))
 
     @property
     def title(self) -> str | None:

--- a/core/parsers/bilibili/opus.py
+++ b/core/parsers/bilibili/opus.py
@@ -27,7 +27,7 @@ class Author(Struct):
     face: str
     mid: int
     pub_time: str
-    pub_ts: int
+    pub_ts: str | int | float
 
 
 class Image(Struct):
@@ -123,7 +123,7 @@ class OpusItem(Struct):
         """获取发布时间戳"""
         for module in self.item.modules:
             if module.module_type == "MODULE_TYPE_AUTHOR" and module.module_author:
-                return module.module_author.pub_ts
+                return int(float(module.module_author.pub_ts))
         return None
 
     def gen_text_img(self) -> Generator[TextNode | ImageNode, None, None]:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: astrbot_plugin_parser
 display_name: 万能解析器
 desc: 高性能低耦合的万能链接解析器。支持的类型：视频、图集、音频。 支持的平台：A站、B站、抖音、tiktok、微博、小红书、快手、油管、X...
 help: 略
-version: v1.5.4
+version: v1.5.5
 author: Zhalslar
 repo: https://github.com/Zhalslar/astrbot_plugin_parser
 


### PR DESCRIPTION
## Summary by Sourcery

处理缺失的 `curl_cffi` 依赖以支持 Bilibili 解析器，并使 Bilibili 的 dynamic/opus 时间戳字段在遇到非整数值时更加健壮。

Bug Fixes:
- 当未安装 `curl_cffi` 时，为 Bilibili 解析器的初始化添加保护，并给出明确的错误提示。
- 当来源提供字符串或浮点数值时，将 Bilibili 的 dynamic 和 opus 发表时间戳字段规范化为整数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing curl_cffi dependency for the Bilibili parser and make Bilibili dynamic/opus timestamp fields robust to non-integer values.

Bug Fixes:
- Guard Bilibili parser initialization with a clear error when curl_cffi is not installed.
- Normalize Bilibili dynamic and opus publication timestamp fields to integers when the source provides string or float values.

</details>