### PR TITLE
Feat(qqzone)：增加了qq空间的原分辨率解析解决方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _✨ 链接解析器 ✨_
 | twitter | 链接                              | ✅​  | ✅​  | ❌️  |
 | Iwara | 链接                              | ✅​  | ✅​  | ❌️  |
 | Pixiv | 链接 / pid                         | ✅​  | ✅​  | ❌️  |
+| QQ空间 | 公开分享链接/卡片                 | ✅​  | ✅​  | ❌️  |
 
 本插件目标：凡是链接皆可解析！尽请期待更新（如果可以,请提交PR）
 
@@ -63,6 +64,20 @@ _✨ 链接解析器 ✨_
 ## ⚙️ 配置
 
 请在astrbot的插件配置面板查看并修改
+
+### QQ空间解析器
+
+QQ空间解析器作为可选模板提供，支持 `h5.qzone.qq.com/ugc/share`、`mobile.qzone.qq.com/l` 等公开分享链接，并优先解析动态中的原图/原视频。未配置登录态或登录态不可用时，会自动回退到公开分享页可获取的媒体。
+
+可选登录态来源：
+
+- **SnowLuma 自动（推荐）**：调用 SnowLuma OneBot HTTP `get_credentials`，固定请求 `domain=qzone.qq.com`，短时缓存凭证；QQ空间接口出现登录态异常时会清缓存、重新获取并自动重试一次。
+- **手动 Cookies**：可直接填写 `uin/p_uin`、`skey`、`p_skey` 等 Cookie；SnowLuma 获取失败时也会作为备用登录态。
+- 两种登录态都不可用时，解析器仍保留公开 H5 fallback，不要求用户必须部署 SnowLuma。
+
+SnowLuma HTTP 地址默认为 `http://127.0.0.1:3000`。这里填写的是 **OneBot HTTP API 地址，不是 WebSocket 地址**；如果 HTTP API 配置了 `access_token`，同时填写对应的 SnowLuma Access Token。QQ 本体已掉线或需要重新登录时，需要先恢复 QQ 登录，单独刷新 `p_skey` 无法恢复失效的 QQ 会话。
+
+> QQ空间登录态只用于回查当前公开分享动态对应的媒体详情，不用于绕过动态自身的访问权限。
 
 ## 🎉 指令
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -245,6 +245,69 @@
                     }
                 }
             },
+            "qzone": {
+                "name": "QQ空间解析器",
+                "items": {
+                    "enable": {
+                        "description": "启用",
+                        "type": "bool",
+                        "default": false
+                    },
+                    "use_proxy": {
+                        "description": "使用代理",
+                        "type": "bool",
+                        "default": false
+                    },
+                    "qzone_credential_source": {
+                        "description": "QQ空间登录态来源",
+                        "hint": "推荐 SnowLuma 自动：通过 SnowLuma 当前已登录 QQ 获取 qzone.qq.com 凭证；失败时仍会尝试下方手动 Cookies。",
+                        "type": "string",
+                        "options": [
+                            "snowluma",
+                            "manual"
+                        ],
+                        "labels": [
+                            "SnowLuma 自动（推荐）",
+                            "仅手动 Cookies"
+                        ],
+                        "default": "snowluma"
+                    },
+                    "snowluma_http_url": {
+                        "description": "SnowLuma OneBot HTTP 地址",
+                        "hint": "填写 SnowLuma 的 HTTP API 地址，不是正向 WebSocket 地址。例：http://127.0.0.1:3000",
+                        "type": "string",
+                        "default": "http://127.0.0.1:3000"
+                    },
+                    "snowluma_access_token": {
+                        "description": "SnowLuma Access Token",
+                        "hint": "SnowLuma HTTP API 未配置鉴权时可留空；已配置则填写对应 OneBot access_token。",
+                        "type": "string",
+                        "default": ""
+                    },
+                    "snowluma_credential_cache_seconds": {
+                        "description": "SnowLuma 凭证缓存秒数",
+                        "hint": "减少重复获取凭证请求。QQ空间接口出现登录态异常时会立即清缓存、自动刷新并重试一次。",
+                        "type": "int",
+                        "slider": {
+                            "min": 0,
+                            "max": 3600,
+                            "step": 30
+                        },
+                        "default": 300
+                    },
+                    "cookies": {
+                        "description": "手动 Cookies（备用）",
+                        "hint": "选填；SnowLuma 自动获取失败时作为备用。建议包含 uin/p_uin、skey、p_skey。选择“仅手动 Cookies”时直接使用这里。",
+                        "type": "text",
+                        "default": ""
+                    },
+                    "send_blue_links": {
+                        "description": "额外发送动态中的外部链接标题和链接",
+                        "type": "bool",
+                        "default": false
+                    }
+                }
+            },
             "shipinhao": {
                 "name": "微信视频号解析器",
                 "items": {

--- a/core/config.py
+++ b/core/config.py
@@ -161,6 +161,11 @@ class ParserItem(ConfigNode):
     video_quality: str | None
     nsfw: str | None
     max_page: int | None
+    send_blue_links: bool | None
+    qzone_credential_source: str | None
+    snowluma_http_url: str | None
+    snowluma_access_token: str | None
+    snowluma_credential_cache_seconds: int | None
 
     @property
     def name(self) -> str:
@@ -185,6 +190,7 @@ class ParserConfig(ConfigNodeContainer):
     iwara: ParserItem
     shipinhao: ParserItem
     pixiv: ParserItem
+    qzone: ParserItem
 
     def __init__(self, nodes: list[dict[str, Any]]):
         super().__init__(nodes, item_cls=ParserItem)

--- a/core/parsers/__init__.py
+++ b/core/parsers/__init__.py
@@ -7,6 +7,7 @@ from .iwara import IwaraParser
 from .kuaishou import KuaiShouParser
 from .ncm import NCMParser
 from .nga import NGAParser
+from .qzone import QZoneParser
 from .shipinhao import ShipinhaoParser
 from .tiktok import TikTokParser
 from .twitter import TwitterParser
@@ -26,6 +27,7 @@ __all__ = [
     "KuaiShouParser",
     "NCMParser",
     "NGAParser",
+    "QZoneParser",
     "TikTokParser",
     "TwitterParser",
     "WeiBoParser",

--- a/core/parsers/qzone.py
+++ b/core/parsers/qzone.py
@@ -1,0 +1,1359 @@
+"""QQ 空间公开分享页解析。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from html import unescape
+from math import isfinite
+from re import Match, findall, search, sub
+from typing import ClassVar
+from urllib.parse import parse_qs, urljoin, urlsplit
+
+from aiohttp import ClientError
+from bs4 import BeautifulSoup, Tag
+
+from ..config import PluginConfig
+from ..cookie import CookieJar
+from ..data import MediaContent, Platform, SendGroup, TextContent
+from ..download import Downloader
+from ..exception import ParseException
+from ..qzone_api import QZoneApiClient, SnowLumaCredentialProvider
+from ..qzone_link import LinkPreview, inspect_link
+from .base import BaseParser, handle
+
+
+@dataclass(slots=True)
+class _QZoneVideo:
+    url: str | None = None
+    cover_url: str | None = None
+    duration: float = 0
+    media_indices: set[str] = field(default_factory=set)
+    unavailable: bool = False
+    topic_id: str | None = None
+    pic_key: str | None = None
+
+
+@dataclass(slots=True)
+class _QZoneImageRef:
+    index: str
+    url: str
+    fallback_url: str | None = None
+    topic_id: str | None = None
+    pic_key: str | None = None
+
+
+def _balanced_object(source: str, start: int) -> str | None:
+    if start < 0 or start >= len(source) or source[start] != "{":
+        return None
+
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    for index in range(start, len(source)):
+        character = source[index]
+        next_character = source[index + 1 : index + 2]
+        if line_comment:
+            if character in "\r\n":
+                line_comment = False
+            continue
+        if block_comment:
+            if character == "*" and next_character == "/":
+                block_comment = False
+            continue
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+
+        if character in {'"', "'", "`"}:
+            quote = character
+        elif character == "/" and next_character == "/":
+            line_comment = True
+        elif character == "/" and next_character == "*":
+            block_comment = True
+        elif character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+            if depth < 0:
+                return None
+    return None
+
+
+def _frontpage_object_starts(source: str):
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = 0
+    while index < len(source):
+        character = source[index]
+        next_character = source[index + 1 : index + 2]
+        if line_comment:
+            if character in "\r\n":
+                line_comment = False
+        elif block_comment:
+            if character == "*" and next_character == "/":
+                block_comment = False
+                index += 1
+        elif quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+        elif character in {'"', "'", "`"}:
+            quote = character
+        elif character == "/" and next_character == "/":
+            line_comment = True
+            index += 1
+        elif character == "/" and next_character == "*":
+            block_comment = True
+            index += 1
+        elif source.startswith("FrontPage", index):
+            before = source[index - 1] if index else ""
+            end = index + len("FrontPage")
+            if not before or not (before.isalnum() or before in "_$"):
+                cursor = end
+                while cursor < len(source) and source[cursor].isspace():
+                    cursor += 1
+                if cursor < len(source) and source[cursor] == "=":
+                    cursor += 1
+                    while cursor < len(source) and source[cursor].isspace():
+                        cursor += 1
+                    if cursor < len(source) and source[cursor] == "{":
+                        yield cursor
+        index += 1
+
+
+def _extract_frontpage_data(html: str) -> dict[str, object] | None:
+    scripts = BeautifulSoup(html, "html.parser").find_all("script")
+    sources = [script.get_text() for script in scripts] if scripts else [html]
+    for source in sources:
+        if (data := _extract_frontpage_source(source)) is not None:
+            return data
+    return None
+
+
+def _extract_frontpage_source(source: str) -> dict[str, object] | None:
+    for outer_start in _frontpage_object_starts(source):
+        outer = _balanced_object(source, outer_start)
+        if outer is not None and (
+            data := _extract_top_level_data(outer)
+        ) is not None:
+            return data
+    return None
+
+
+def _extract_top_level_data(outer: str) -> dict[str, object] | None:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = 0
+    while index < len(outer):
+        character = outer[index]
+        next_character = outer[index + 1 : index + 2]
+        if line_comment:
+            if character in "\r\n":
+                line_comment = False
+            index += 1
+            continue
+        if block_comment:
+            if character == "*" and next_character == "/":
+                block_comment = False
+                index += 1
+            index += 1
+            continue
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            index += 1
+            continue
+
+        key_end: int | None = None
+        if depth == 1 and outer.startswith(('"data"', "'data'"), index):
+            key_end = index + len('"data"')
+        elif depth == 1 and outer.startswith("data", index):
+            before = outer[index - 1] if index else ""
+            after = outer[index + 4 : index + 5]
+            if not (before.isalnum() or before in "_$") and not (
+                after.isalnum() or after in "_$"
+            ):
+                key_end = index + len("data")
+
+        if key_end is not None:
+            value_start = key_end
+            while value_start < len(outer) and outer[value_start].isspace():
+                value_start += 1
+            if value_start < len(outer) and outer[value_start] == ":":
+                value_start += 1
+                while value_start < len(outer) and outer[value_start].isspace():
+                    value_start += 1
+                value = _balanced_object(outer, value_start)
+                if value is None:
+                    return None
+                try:
+                    decoded = json.loads(value)
+                except (json.JSONDecodeError, TypeError):
+                    return None
+                return decoded if isinstance(decoded, dict) else None
+
+        if character in {'"', "'", "`"}:
+            quote = character
+        elif character == "/" and next_character == "/":
+            line_comment = True
+            index += 1
+        elif character == "/" and next_character == "*":
+            block_comment = True
+            index += 1
+        elif character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+        index += 1
+    return None
+
+
+@dataclass(slots=True)
+class QZonePost:
+    author_name: str
+    avatar_url: str | None
+    text: str
+    link_urls: list[str]
+    timestamp: int | None
+    image_urls: list[str]
+    video_url: str | None
+    video_cover_url: str | None
+    video_unavailable: bool = False
+    video_duration: float = 0.0
+    image_refs: list[_QZoneImageRef] = field(default_factory=list)
+    video_topic_id: str | None = None
+    video_pic_key: str | None = None
+
+
+class QZoneParser(BaseParser):
+    platform: ClassVar[Platform] = Platform(name="qzone", display_name="QQ空间")
+    BLUE_LINK_CONCURRENCY_LIMIT: ClassVar[int] = 3
+
+    def __init__(self, config: PluginConfig, downloader: Downloader):
+        super().__init__(config, downloader)
+        self.headers.update(
+            {
+                "user-agent": (
+                    "Mozilla/5.0 (Linux; Android 13; Mobile) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Mobile Safari/537.36"
+                ),
+                "accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,*/*;q=0.8"
+                ),
+            }
+        )
+        self._qzone_cookie_jar: CookieJar | None = None
+        self._qzone_credential_provider: SnowLumaCredentialProvider | None = None
+        self._snowluma_provider_options: tuple[str, str, int] | None = None
+        self._qzone_api: QZoneApiClient | None = None
+        try:
+            parser_cfg = self.cfg.parser.qzone
+            # 正常 AstrBot 运行环境必定有 cookie_dir；测试桩可能没有。
+            # 手动 Cookie 始终保留为 SnowLuma 不可用时的 fallback。
+            if hasattr(self.cfg, "cookie_dir"):
+                self._qzone_cookie_jar = CookieJar(
+                    self.cfg, parser_cfg, "qzone.qq.com"
+                )
+
+            # Provider 延迟到真正解析时再创建，避免插件构造阶段提前创建
+            # aiohttp ClientSession（此时 AstrBot 事件循环可能尚未启动）。
+            if hasattr(parser_cfg, "qzone_credential_source"):
+                credential_source = str(
+                    getattr(parser_cfg, "qzone_credential_source", None)
+                    or "snowluma"
+                ).strip().lower()
+                if credential_source != "manual":
+                    base_url = str(
+                        getattr(parser_cfg, "snowluma_http_url", None)
+                        or "http://127.0.0.1:3000"
+                    ).strip()
+                    access_token = str(
+                        getattr(parser_cfg, "snowluma_access_token", None) or ""
+                    ).strip()
+                    try:
+                        cache_seconds = int(
+                            getattr(parser_cfg, "snowluma_credential_cache_seconds", None)
+                            or 300
+                        )
+                    except (TypeError, ValueError):
+                        cache_seconds = 300
+                    self._snowluma_provider_options = (
+                        base_url,
+                        access_token,
+                        cache_seconds,
+                    )
+        except (AttributeError, TypeError, OSError):
+            self._qzone_cookie_jar = None
+            self._qzone_credential_provider = None
+            self._snowluma_provider_options = None
+
+    @staticmethod
+    def _normalize_url(value: object, base_url: str) -> str | None:
+        if not isinstance(value, str):
+            return None
+        value = unescape(value).strip()
+        if not value:
+            return None
+        try:
+            normalized = urljoin(base_url, value)
+            parsed = urlsplit(normalized)
+        except ValueError:
+            return None
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            return None
+        return normalized
+
+    @staticmethod
+    def _deduplicate(values: list[str]) -> list[str]:
+        return list(dict.fromkeys(values))
+
+    @staticmethod
+    def _looks_like_image_url(url: str) -> bool:
+        text = url.lower()
+        if text.startswith(("data:", "javascript:")):
+            return False
+        return bool(
+            "qpic.cn" in text
+            or "photo.store.qq.com" in text
+            or "gtimg.cn" in text
+            or search(r"\.(?:jpe?g|png|webp|gif)(?:[?#]|$)", text)
+        )
+
+    @classmethod
+    def _to_qzone_original_url(cls, url: str) -> str:
+        """把 QQ 图片 CDN 明确的预览尺寸档提升到原图档。"""
+        if "/psc?/" not in url.lower():
+            return url
+        upgraded = sub(r"!/(?:m|c|r)(?=&|$)", "!/b", url, flags=2)
+        upgraded = sub(
+            r"(/single-photo/)(?:m|c|r)(?=&|$)",
+            r"\1b",
+            upgraded,
+            flags=2,
+        )
+        return upgraded
+
+    @staticmethod
+    def _origin_score(url: str) -> int:
+        text = url.lower()
+        score = 0
+        if search(r"(?:raw|origin|original|large|big|orignal)", text):
+            score += 8
+        if search(r"/0(?:[?#]|$)", text):
+            score += 5
+        if search(r"/(?:b|2000|1600)(?:[/?#]|$)", text):
+            score += 4
+        if search(r"(?:small|thumb|s_|/m(?:[/?#]|$)|/100(?:[/?#]|$)|/200(?:[/?#]|$))", text):
+            score -= 5
+        sizes = [
+            int(value)
+            for value in findall(r"/(\d{2,4})(?=/|\?|#|$)", text)
+        ]
+        size = sizes[-1] if sizes else 0
+        if size >= 2000:
+            score += 8
+        elif size >= 1600:
+            score += 7
+        elif size >= 1280:
+            score += 6
+        elif size >= 1024:
+            score += 5
+        elif size >= 800:
+            score += 4
+        elif size >= 640:
+            score += 2
+        elif size >= 400:
+            score -= 1
+        elif size >= 280:
+            score -= 2
+        elif size >= 200:
+            score -= 4
+        elif size:
+            score -= 6
+        return score
+
+    @classmethod
+    def _pick_original_candidate(
+        cls, values: list[object], base_url: str
+    ) -> tuple[str | None, str | None]:
+        normalized: list[str] = []
+        for value in values:
+            url = cls._normalize_url(value, base_url)
+            if url is None or not cls._looks_like_image_url(url):
+                continue
+            normalized.append(url)
+        normalized = cls._deduplicate(normalized)
+        if not normalized:
+            return None, None
+
+        fallback = normalized[0]
+        expanded = cls._deduplicate(
+            [candidate for url in normalized for candidate in (cls._to_qzone_original_url(url), url)]
+        )
+        best = max(expanded, key=cls._origin_score)
+        return best, fallback
+
+    @staticmethod
+    def _first_string(mapping: object, *keys: str) -> str | None:
+        if not isinstance(mapping, dict):
+            return None
+        for key in keys:
+            value = mapping.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    @classmethod
+    def _mapping_image_candidates(cls, mapping: object) -> list[object]:
+        if not isinstance(mapping, dict):
+            return []
+        origin_fields = (
+            "picrawurl",
+            "rawurl",
+            "raw_url",
+            "originurl",
+            "origin_url",
+            "origin",
+            "picoriginurl",
+            "picOriginUrl",
+            "url4",
+            "url3",
+            "picbigurl",
+            "bigurl",
+            "big_url",
+            "largeurl",
+            "large_url",
+            "hdurl",
+            "hd_url",
+            "raw",
+        )
+        thumb_fields = (
+            "smallurl",
+            "small_url",
+            "thumb",
+            "thumburl",
+            "thumb_url",
+            "picsmall",
+            "url1",
+            "url2",
+            "url",
+            "pre",
+            "preview",
+        )
+        values: list[object] = [mapping.get(key) for key in (*origin_fields, *thumb_fields)]
+        for value in mapping.values():
+            if isinstance(value, str):
+                values.append(value)
+        return values
+
+    @classmethod
+    def _extract_script_images(
+        cls, html: str, base_url: str
+    ) -> dict[str, _QZoneImageRef]:
+        payload = _extract_frontpage_data(html)
+        if payload is None:
+            return {}
+        data = payload.get("data")
+        cell_pic = data.get("cell_pic") if isinstance(data, dict) else None
+        picdata = cell_pic.get("picdata") if isinstance(cell_pic, dict) else None
+        result: dict[str, _QZoneImageRef] = {}
+        for index, item in cls._mapping_values(picdata):
+            if not isinstance(item, dict):
+                continue
+            flag = item.get("videoflag")
+            if (type(flag) is int and flag == 1) or (
+                isinstance(flag, str) and flag == "1"
+            ):
+                continue
+            best, fallback = cls._pick_original_candidate(
+                cls._mapping_image_candidates(item), base_url
+            )
+            if best is None:
+                continue
+            result[index] = _QZoneImageRef(
+                index=index,
+                url=best,
+                fallback_url=fallback,
+                topic_id=cls._first_string(
+                    item, "topicId", "topicid", "albumId", "albumid", "album_id"
+                ),
+                pic_key=cls._first_string(
+                    item, "picKey", "pic_key", "lloc", "pic_id", "id", "key"
+                ),
+            )
+        return result
+
+    @classmethod
+    def _image_ref_from_node(
+        cls,
+        image_node: Tag,
+        feed: Tag,
+        base_url: str,
+        default_index: str,
+    ) -> _QZoneImageRef | None:
+        params_raw = unescape(str(image_node.get("data-params") or image_node.get("data-param") or ""))
+        params = parse_qs(params_raw, keep_blank_values=True)
+        index = (params.get("index") or [default_index])[0]
+
+        containers = [image_node]
+        anchor = image_node.find_parent("a")
+        if isinstance(anchor, Tag):
+            containers.append(anchor)
+
+        candidates: list[object] = []
+        pic_key: str | None = None
+        topic_id: str | None = None
+        attrs = (
+            "data-originurl",
+            "data-origin",
+            "data-original",
+            "data-bigurl",
+            "data-raw",
+            "data-picurl",
+            "data-pic",
+            "data-url",
+            "data-feedlazy",
+            "data-src",
+            "src",
+            "href",
+        )
+        for container in containers:
+            for attr in attrs:
+                value = container.get(attr)
+                if not isinstance(value, str) or not value.strip():
+                    continue
+                if attr == "data-originurl":
+                    candidates.extend(part for part in value.split("|") if part)
+                else:
+                    candidates.append(value)
+
+            pickey = container.get("data-pickey")
+            if isinstance(pickey, str) and pickey.strip():
+                parts = [part.strip() for part in pickey.split(",") if part.strip()]
+                if parts:
+                    first = parts[0]
+                    if not first.lower().startswith(("http://", "https://", "//")):
+                        pic_key = first
+                        parts = parts[1:]
+                    candidates.extend(parts)
+
+            own_params = parse_qs(
+                unescape(str(container.get("data-param") or container.get("data-params") or "")),
+                keep_blank_values=True,
+            )
+            pic_key = pic_key or next(
+                (
+                    own_params[key][0]
+                    for key in ("picKey", "pickey", "pic_key", "lloc")
+                    if own_params.get(key)
+                ),
+                None,
+            )
+            topic_id = topic_id or next(
+                (
+                    own_params[key][0]
+                    for key in ("topicId", "topicid", "albumId", "albumid")
+                    if own_params.get(key)
+                ),
+                None,
+            )
+
+        topic_node = feed.select_one("[data-topicid]")
+        if topic_id is None and isinstance(topic_node, Tag):
+            raw_topic = topic_node.get("data-topicid")
+            if isinstance(raw_topic, str) and raw_topic.strip():
+                topic_id = raw_topic.strip()
+
+        best, fallback = cls._pick_original_candidate(candidates, base_url)
+        if best is None:
+            return None
+        return _QZoneImageRef(
+            index=str(index),
+            url=best,
+            fallback_url=fallback,
+            topic_id=topic_id,
+            pic_key=pic_key,
+        )
+
+    def _get_qzone_api(self) -> QZoneApiClient | None:
+        if (
+            self._qzone_credential_provider is None
+            and self._snowluma_provider_options is not None
+        ):
+            base_url, access_token, cache_seconds = self._snowluma_provider_options
+            self._qzone_credential_provider = SnowLumaCredentialProvider(
+                self.session,
+                base_url=base_url,
+                access_token=access_token,
+                cache_seconds=cache_seconds,
+            )
+        if self._qzone_cookie_jar is None and self._qzone_credential_provider is None:
+            return None
+        if self._qzone_api is None:
+            self._qzone_api = QZoneApiClient(
+                self.session,
+                self._qzone_cookie_jar,
+                proxy=self.proxy,
+                credential_provider=self._qzone_credential_provider,
+            )
+        return self._qzone_api
+
+    def _share_headers(self, url: str) -> dict[str, str]:
+        headers = self.headers.copy()
+        if self._qzone_cookie_jar is not None:
+            cookie = self._qzone_cookie_jar.get_cookie_header_for_url(url)
+            if cookie:
+                headers["Cookie"] = cookie
+        return headers
+
+    def _media_headers(self, page_url: str) -> dict[str, str]:
+        api = self._get_qzone_api()
+        if api is not None and api.available:
+            headers = self.headers.copy()
+            headers.update(api.media_headers(page_url))
+            return headers
+        return self.headers
+
+    @classmethod
+    def _feed_image_ref(
+        cls,
+        photo: object,
+        *,
+        index: int,
+        topic_id: str | None,
+        base_url: str,
+    ) -> _QZoneImageRef | None:
+        if not isinstance(photo, dict):
+            return None
+        best, fallback = cls._pick_original_candidate(
+            [
+                photo.get("raw"),
+                photo.get("picrawurl"),
+                photo.get("rawurl"),
+                photo.get("originurl"),
+                photo.get("picbigurl"),
+                photo.get("bigurl"),
+                photo.get("url"),
+                photo.get("picsmallurl"),
+                photo.get("smallurl"),
+            ],
+            base_url,
+        )
+        if best is None:
+            return None
+        return _QZoneImageRef(
+            index=str(index),
+            url=best,
+            fallback_url=fallback,
+            topic_id=topic_id,
+            pic_key=cls._first_string(
+                photo, "picKey", "pic_key", "lloc", "pic_id", "id", "key"
+            ),
+        )
+
+    @staticmethod
+    def _feed_is_video(photo: object) -> bool:
+        if not isinstance(photo, dict):
+            return False
+        flag = photo.get("is_video")
+        return bool(
+            flag is True
+            or flag == 1
+            or flag == "1"
+            or photo.get("videourl")
+            or photo.get("video_url")
+        )
+
+    @classmethod
+    def _apply_feed_media(
+        cls,
+        post: QZonePost,
+        feed: object,
+        page_url: str,
+    ) -> None:
+        if not isinstance(feed, dict):
+            return
+        photos = feed.get("photos")
+        if not isinstance(photos, list):
+            return
+        topic_id = cls._first_string(
+            feed, "albumid", "albumId", "album_id", "topicId", "topicid"
+        )
+        image_refs: list[_QZoneImageRef] = []
+        for index, photo in enumerate(photos):
+            if not isinstance(photo, dict):
+                continue
+            if cls._feed_is_video(photo):
+                video_url = next(
+                    (
+                        normalized
+                        for value in (
+                            photo.get("video_download_url"),
+                            photo.get("download_url"),
+                            photo.get("videourl"),
+                            photo.get("video_url"),
+                            photo.get("url3"),
+                        )
+                        if (normalized := cls._normalize_url(value, page_url))
+                    ),
+                    None,
+                )
+                if video_url:
+                    post.video_url = video_url
+                    post.video_unavailable = False
+                cover = next(
+                    (
+                        normalized
+                        for value in (
+                            photo.get("cover_url"),
+                            photo.get("pic_url"),
+                            photo.get("picsmallurl"),
+                            photo.get("url1"),
+                            photo.get("url"),
+                        )
+                        if (normalized := cls._normalize_url(value, page_url))
+                    ),
+                    None,
+                )
+                if cover:
+                    post.video_cover_url = cover
+                post.video_topic_id = topic_id or post.video_topic_id
+                post.video_pic_key = (
+                    cls._first_string(
+                        photo,
+                        "picKey",
+                        "pic_key",
+                        "lloc",
+                        "videokey",
+                        "video_id",
+                        "id",
+                    )
+                    or post.video_pic_key
+                )
+                try:
+                    duration = float(
+                        photo.get("video_time")
+                        or photo.get("videotime")
+                        or photo.get("duration")
+                        or 0
+                    )
+                except (TypeError, ValueError, OverflowError):
+                    duration = 0.0
+                if duration >= 1000:
+                    duration /= 1000
+                if duration > 0:
+                    post.video_duration = duration
+                continue
+
+            ref = cls._feed_image_ref(
+                photo,
+                index=index,
+                topic_id=topic_id,
+                base_url=page_url,
+            )
+            if ref is not None:
+                image_refs.append(ref)
+
+        if image_refs:
+            post.image_refs = image_refs
+            post.image_urls = cls._deduplicate([ref.url for ref in image_refs])
+
+    async def _upgrade_post_media(self, post: QZonePost, page_url: str) -> QZonePost:
+        api = self._get_qzone_api()
+        if api is None or not await api.ensure_auth():
+            return post
+
+        query = parse_qs(urlsplit(page_url).query)
+        host_uin = (query.get("res_uin") or [""])[0]
+        cell_id = (query.get("cellid") or [""])[0]
+        if not host_uin:
+            return post
+
+        # 第一优先：用照片动态接口按分享页时间点回查同一条动态。
+        # 这个响应直接给 raw/picrawurl/picbigurl/videourl，并带 albumid + picKey。
+        try:
+            feed_payload = await api.get_photo_feed(
+                host_uin=host_uin,
+                begintime=(post.timestamp + 1) if post.timestamp else 0,
+            )
+            feed = api.find_feed(
+                feed_payload,
+                cell_id=cell_id,
+                timestamp=post.timestamp,
+            )
+            if feed is not None:
+                self._apply_feed_media(post, feed, page_url)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # 原媒体增强是 best-effort；任何接口结构变更都必须回退 H5。
+            pass
+
+        async def upgrade_image(ref: _QZoneImageRef) -> str:
+            if not ref.topic_id or not ref.pic_key:
+                return ref.url
+            detail = await api.get_media_detail(
+                host_uin=host_uin,
+                topic_id=ref.topic_id,
+                pic_key=ref.pic_key,
+            )
+            if detail is None or not detail.best_image_url:
+                return ref.url
+            return self._normalize_url(detail.best_image_url, page_url) or ref.url
+
+        if post.image_refs:
+            upgraded = await asyncio.gather(*(upgrade_image(ref) for ref in post.image_refs))
+            post.image_urls = self._deduplicate(list(upgraded))
+
+        if post.video_topic_id and post.video_pic_key:
+            detail = await api.get_media_detail(
+                host_uin=host_uin,
+                topic_id=post.video_topic_id,
+                pic_key=post.video_pic_key,
+            )
+            if detail is not None and detail.is_video:
+                if detail.best_video_url:
+                    post.video_url = (
+                        self._normalize_url(detail.best_video_url, page_url)
+                        or post.video_url
+                    )
+                    post.video_unavailable = False
+                if detail.video_cover_url:
+                    post.video_cover_url = (
+                        self._normalize_url(detail.video_cover_url, page_url)
+                        or post.video_cover_url
+                    )
+                if detail.video_duration > 0:
+                    post.video_duration = detail.video_duration
+        return post
+
+
+    @staticmethod
+    def _mapping_values(value: object) -> list[tuple[str, object]]:
+        if isinstance(value, dict):
+            return [(str(key), item) for key, item in value.items()]
+        if isinstance(value, list):
+            return [(str(index), item) for index, item in enumerate(value)]
+        return []
+
+    @classmethod
+    def _first_nested_url(
+        cls, value: object, base_url: str
+    ) -> str | None:
+        for _, item in cls._mapping_values(value):
+            if not isinstance(item, dict):
+                continue
+            if normalized := cls._normalize_url(item.get("url"), base_url):
+                return normalized
+        return None
+
+    @classmethod
+    def _extract_script_video(cls, html: str, base_url: str) -> _QZoneVideo:
+        payload = _extract_frontpage_data(html)
+        if payload is None:
+            return _QZoneVideo()
+
+        data = payload.get("data")
+        cell_pic = data.get("cell_pic") if isinstance(data, dict) else None
+        picdata = cell_pic.get("picdata") if isinstance(cell_pic, dict) else None
+        first_unavailable: _QZoneVideo | None = None
+        for index, item in cls._mapping_values(picdata):
+            if not isinstance(item, dict):
+                continue
+            flag = item.get("videoflag")
+            if not (
+                (type(flag) is int and flag == 1)
+                or (isinstance(flag, str) and flag == "1")
+            ):
+                continue
+
+            raw = item.get("videodata")
+            if not isinstance(raw, dict):
+                if first_unavailable is None:
+                    first_unavailable = _QZoneVideo(
+                        media_indices={index}, unavailable=True
+                    )
+                continue
+
+            url = next(
+                (
+                    normalized
+                    for candidate in (
+                        raw.get("videourl"),
+                        raw.get("actionurl"),
+                    )
+                    if (
+                        normalized := cls._normalize_url(candidate, base_url)
+                    )
+                ),
+                None,
+            )
+            if url is None:
+                url = cls._first_nested_url(raw.get("videourls"), base_url)
+
+            cover_url = cls._first_nested_url(raw.get("coverurl"), base_url)
+            try:
+                duration = float(raw.get("videotime", 0)) / 1000
+            except (TypeError, ValueError, OverflowError):
+                duration = 0.0
+            if not isfinite(duration) or duration < 0:
+                duration = 0.0
+
+            video = _QZoneVideo(
+                url=url,
+                cover_url=cover_url,
+                duration=duration,
+                media_indices={index},
+                unavailable=url is None,
+                topic_id=cls._first_string(
+                    item, "topicId", "topicid", "albumId", "albumid", "album_id"
+                ),
+                pic_key=cls._first_string(
+                    item, "picKey", "pic_key", "lloc", "video_id", "vid", "id", "key"
+                ),
+            )
+            if url is not None:
+                return video
+            if first_unavailable is None:
+                first_unavailable = video
+        return first_unavailable or _QZoneVideo()
+
+    @staticmethod
+    def _strip_unmatched_closing_delimiters(value: str) -> str:
+        pairs = {")": "(", "]": "[", "}": "{"}
+        while value and (opening := pairs.get(value[-1])):
+            closing = value[-1]
+            if value.count(closing) <= value.count(opening):
+                break
+            value = value[:-1]
+        return value
+
+    @classmethod
+    def _style_url(cls, style: object, base_url: str) -> str | None:
+        if not isinstance(style, str):
+            return None
+        matched = search(
+            r"background-image\s*:\s*url\(\s*(['\"]?)(.*?)\1\s*\)",
+            unescape(style),
+            flags=0,
+        )
+        return cls._normalize_url(matched.group(2), base_url) if matched else None
+
+    @property
+    def _send_blue_links(self) -> bool:
+        try:
+            return bool(self.cfg.parser.qzone.send_blue_links)
+        except AttributeError:
+            return False
+
+    @classmethod
+    async def _inspect_blue_links(cls, urls: list[str]) -> list[LinkPreview]:
+        semaphore = asyncio.Semaphore(cls.BLUE_LINK_CONCURRENCY_LIMIT)
+
+        async def inspect_one(url: str) -> LinkPreview:
+            async with semaphore:
+                try:
+                    return await inspect_link(url)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    return LinkPreview("访问失败", url)
+
+        return list(await asyncio.gather(*(inspect_one(url) for url in urls)))
+
+    @staticmethod
+    def _format_blue_links(previews: list[LinkPreview]) -> str:
+        return "\n".join(
+            value
+            for preview in previews
+            for value in (preview.title, preview.url)
+            if value != ""
+        )
+
+    @classmethod
+    def _resolve_text_link(cls, value: object, base_url: str) -> str | None:
+        """解出 QQ 正文链接跳转器中的公开目标地址。"""
+        resolved = cls._normalize_url(value, base_url)
+        if resolved is None:
+            return None
+
+        parsed = urlsplit(resolved)
+        if parsed.hostname not in {"urlshare.cn", "www.urlshare.cn"}:
+            return resolved
+
+        target_values = parse_qs(parsed.query).get("url")
+        if not target_values:
+            return resolved
+
+        target = target_values[0]
+        return cls._normalize_url(target, resolved) or resolved
+
+    @classmethod
+    def _extract_text(
+        cls, text_node: Tag, base_url: str
+    ) -> tuple[str, list[str]]:
+        link_urls: list[str] = []
+        for link_node in text_node.select("a[href]"):
+            resolved = cls._resolve_text_link(link_node.get("href"), base_url)
+            if resolved is None:
+                continue
+            link_urls.append(resolved)
+
+            label = link_node.get_text(" ", strip=True)
+            replacement = (
+                f"{label}：{resolved}"
+                if label and label != resolved
+                else resolved
+            )
+            link_node.replace_with(replacement)
+
+        return text_node.get_text("\n", strip=True), cls._deduplicate(link_urls)
+
+    @classmethod
+    def _extract_video(
+        cls, root: Tag, base_url: str
+    ) -> tuple[str | None, str | None, bool]:
+        nodes = root.select(
+            "video, .video, [data-video-url], [data-videourl], "
+            "[data-play-url], [data-playurl], [data-v_vidioswfurl], "
+            "[data-v-vidiourl], [data-param], [data-hook*='video']"
+        )
+        video_url: str | None = None
+        cover_url: str | None = None
+        has_video_marker = False
+        video_attrs = (
+            "data-video-url",
+            "data-videourl",
+            "data-play-url",
+            "data-playurl",
+            "data-v_vidioswfurl",
+            "data-v-vidiourl",
+        )
+        cover_attrs = ("poster", "data-poster", "data-cover", "data-cover-url")
+
+        for node in nodes:
+            explicit_video_values = [node.get(attr) for attr in video_attrs]
+            has_explicit_video_attr = any(
+                node.has_attr(attr) for attr in video_attrs
+            )
+            legacy_params = parse_qs(
+                unescape(str(node.get("data-param", ""))),
+                keep_blank_values=True,
+            )
+            has_legacy_video_param = "videosrc" in legacy_params
+            legacy_video_values = legacy_params.get("videosrc", [])
+            cover_candidates = [node.get(attr) for attr in cover_attrs]
+            is_video_element = node.name == "video"
+            is_explicit_container = (
+                node.name not in {"img", "source"}
+                and (
+                    "video" in node.get("class", [])
+                    or "video" in str(node.get("data-hook", ""))
+                )
+            )
+            has_video_selector = (
+                is_video_element
+                or "video" in node.get("class", [])
+                or has_explicit_video_attr
+                or "video" in str(node.get("data-hook", ""))
+            )
+            is_video_container = (
+                any(explicit_video_values)
+                or has_legacy_video_param
+                or (any(cover_candidates) and has_video_selector)
+                or is_explicit_container
+            )
+            if not is_video_element and not is_video_container:
+                continue
+
+            has_video_marker = True
+            if cover_url is None:
+                cover_url = next(
+                    (
+                        normalized
+                        for value in cover_candidates
+                        if (normalized := cls._normalize_url(value, base_url))
+                    ),
+                    None,
+                )
+
+            if is_video_element:
+                video_candidates = [node.get("src")]
+                video_candidates.extend(
+                    source.get("src") for source in node.select("source[src]")
+                )
+            else:
+                video_candidates = explicit_video_values + legacy_video_values
+
+            if video_url is None:
+                video_url = next(
+                    (
+                        normalized
+                        for value in video_candidates
+                        if (normalized := cls._normalize_url(value, base_url))
+                    ),
+                    None,
+                )
+
+        return video_url, cover_url, has_video_marker and video_url is None
+
+    @classmethod
+    def extract_post(cls, html: str, page_url: str) -> QZonePost:
+        soup = BeautifulSoup(html, "html.parser")
+        feed = soup.select_one('.feed[data-hook="info-detail"]')
+        if not isinstance(feed, Tag):
+            raise ParseException("未找到 QQ 空间公开动态")
+
+        script_video = cls._extract_script_video(html, page_url)
+
+        author_name = ""
+        for selector in (
+            ".feed-hd .username",
+            '[data-hook="user-name"]',
+            ".user-name",
+            ".nickname",
+            ".feed-hd .name",
+        ):
+            author_node = feed.select_one(selector)
+            if author_node and (candidate := author_node.get_text(strip=True)):
+                author_name = candidate
+                break
+        if not author_name:
+            author_name = parse_qs(urlsplit(page_url).query).get(
+                "res_uin", ["QQ空间用户"]
+            )[0]
+
+        avatar_url: str | None = None
+        for selector in (
+            ".feed-hd .pic",
+            ".feed-hd .avatar",
+            '.feed-hd [data-hook*="avatar"]',
+        ):
+            avatar_node = feed.select_one(selector)
+            if avatar_node is not None and (
+                avatar_url := cls._style_url(avatar_node.get("style"), page_url)
+            ):
+                break
+
+        body = feed.select_one(".feed-bd")
+        text = ""
+        link_urls: list[str] = []
+        image_urls: list[str] = []
+        image_refs: list[_QZoneImageRef] = []
+        if isinstance(body, Tag):
+            text_node = feed.select_one(".feed-bd .txt")
+            if isinstance(text_node, Tag):
+                text, link_urls = cls._extract_text(text_node, page_url)
+
+            script_images = cls._extract_script_images(html, page_url)
+            for sequence, image_node in enumerate(
+                body.select(
+                    "[data-feedlazy], "
+                    "img[data-hook*='viewPic'][src], "
+                    "img.img[data-params][src]"
+                )
+            ):
+                image_params = image_node.get("data-params")
+                media_index: str | None = None
+                if isinstance(image_params, str):
+                    parsed_image_params = parse_qs(
+                        unescape(image_params), keep_blank_values=True
+                    )
+                    media_values = parsed_image_params.get("index")
+                    media_index = media_values[0] if media_values else None
+                    if media_index and media_index in script_video.media_indices:
+                        continue
+
+                html_ref = cls._image_ref_from_node(
+                    image_node,
+                    feed,
+                    page_url,
+                    media_index or str(sequence),
+                )
+                script_ref = script_images.get(media_index or str(sequence))
+                ref = script_ref or html_ref
+                if ref is None:
+                    continue
+                if script_ref is not None and html_ref is not None:
+                    ref.fallback_url = script_ref.fallback_url or html_ref.fallback_url
+                    ref.topic_id = script_ref.topic_id or html_ref.topic_id
+                    ref.pic_key = script_ref.pic_key or html_ref.pic_key
+                image_refs.append(ref)
+                image_urls.append(ref.url)
+
+            # FrontPage 有时比 DOM 多给出媒体信息（懒加载节点未渲染出来）。
+            known_indices = {ref.index for ref in image_refs}
+            for index, ref in script_images.items():
+                if index in known_indices or index in script_video.media_indices:
+                    continue
+                image_refs.append(ref)
+                image_urls.append(ref.url)
+
+        timestamp: int | None = None
+        data_params = feed.get("data-params")
+        if isinstance(data_params, str) and (
+            timestamp_match := search(r"__(\d{10})(?:\D|$)", data_params)
+        ):
+            timestamp = int(timestamp_match.group(1))
+
+        has_script_video = bool(
+            script_video.url
+            or script_video.unavailable
+            or script_video.media_indices
+        )
+        if has_script_video:
+            video_url = script_video.url
+            video_cover_url = script_video.cover_url
+            video_duration = script_video.duration
+            video_unavailable = script_video.unavailable
+        else:
+            video_url, video_cover_url, video_unavailable = cls._extract_video(
+                feed, page_url
+            )
+            video_duration = 0.0
+        return QZonePost(
+            author_name=author_name,
+            avatar_url=avatar_url,
+            text=text,
+            link_urls=link_urls,
+            timestamp=timestamp,
+            image_urls=cls._deduplicate(image_urls),
+            video_url=video_url,
+            video_cover_url=video_cover_url,
+            video_unavailable=video_unavailable,
+            video_duration=video_duration,
+            image_refs=image_refs,
+            video_topic_id=script_video.topic_id,
+            video_pic_key=script_video.pic_key,
+        )
+
+    @handle(
+        "h5.qzone.qq.com/ugc/share",
+        r"https?://h5\.qzone\.qq\.com/ugc/share/\?[^\s<>\"'，。；！？）】》」』]+",
+    )
+    @handle(
+        "mobile.qzone.qq.com/l",
+        r"https?://mobile\.qzone\.qq\.com/l\?[^\s<>\"'，。；！？）】》」』]+",
+    )
+    async def _parse_share(self, searched: Match[str]):
+        url = self._strip_unmatched_closing_delimiters(
+            unescape(searched.group(0))
+        )
+        html = await self._fetch_html(url)
+        post = self.extract_post(html, url)
+        post = await self._upgrade_post_media(post, url)
+        media_headers = self._media_headers(url)
+
+        contents: list[MediaContent] = []
+        if post.video_url:
+            contents.append(
+                self.create_video_content(
+                    post.video_url,
+                    cover_url=post.video_cover_url,
+                    duration=post.video_duration,
+                    headers=media_headers,
+                )
+            )
+        contents.extend(
+            self.create_image_contents(post.image_urls, headers=media_headers)
+        )
+
+        if not post.text and not contents:
+            raise ParseException("QQ空间动态没有可发送的内容")
+
+        extra = {}
+        if post.video_unavailable:
+            notice = "页面包含视频，但未公开可下载的视频地址"
+            extra["info"] = notice
+            if not contents and notice not in post.text:
+                post.text = f"{post.text}\n\n{notice}".strip()
+
+        author = self.create_author(
+            post.author_name,
+            post.avatar_url,
+            headers=self.headers,
+        )
+        result = self.result(
+            author=author,
+            text=post.text,
+            timestamp=post.timestamp,
+            url=url,
+            contents=contents,
+            send_groups=(
+                [SendGroup(contents=contents, render_card=True)]
+                if contents
+                else []
+            ),
+            extra=extra,
+        )
+        if not self._send_blue_links or not post.link_urls:
+            return result
+
+        message = self._format_blue_links(
+            await self._inspect_blue_links(post.link_urls)
+        )
+        if not message:
+            return result
+
+        if contents:
+            result.send_groups.append(
+                SendGroup(contents=[TextContent(message)])
+            )
+        else:
+            fallback = "\n".join(
+                part for part in (result.header, result.text) if part
+            ).strip()
+            result.send_groups = [
+                SendGroup(contents=[TextContent(fallback)]),
+                SendGroup(contents=[TextContent(message)]),
+            ]
+        return result
+
+    async def _fetch_html(self, url: str) -> str:
+        try:
+            request_kwargs = {
+                "headers": self._share_headers(url),
+                "allow_redirects": True,
+            }
+            if self.proxy:
+                request_kwargs["proxy"] = self.proxy
+            async with self.session.get(url, **request_kwargs) as response:
+                if response.status >= 400:
+                    raise ClientError(f"HTTP {response.status} {response.reason}")
+                if self._qzone_cookie_jar is not None:
+                    try:
+                        set_cookies = response.headers.getall("Set-Cookie", [])
+                    except Exception:
+                        set_cookies = []
+                    if set_cookies:
+                        self._qzone_cookie_jar.update_from_response(list(set_cookies))
+                return await response.text()
+        except (ClientError, asyncio.TimeoutError) as exc:
+            raise ParseException(f"QQ空间分享页请求失败: {exc}") from exc
+
+
+__all__ = ["QZoneParser", "QZonePost"]

--- a/core/qzone_api.py
+++ b/core/qzone_api.py
@@ -1,0 +1,634 @@
+"""QQ 空间原媒体接口与 SnowLuma 动态凭证支持。
+
+这里只实现万能解析器需要的只读能力：
+- 优先从 SnowLuma OneBot HTTP ``get_credentials`` 动态获取 qzone.qq.com 凭证；
+- SnowLuma 不可用时自动回退插件手动 Cookie；
+- 基于当前 p_skey / SnowLuma csrf_token 调用照片动态与 floatview 接口；
+- 登录态疑似失效时强制向 SnowLuma 刷新一次并自动重试；
+- 保存服务端刷新出的 qq_photo_key；
+- 为 qpic / photo.qq.com 媒体下载构造必要请求头。
+
+QQ 空间 CGI 协议行为按公开网页请求独立实现；SnowLuma 调用只使用其
+OneBot HTTP action，不读取 SnowLuma 私有文件或进程内存。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import json
+import time
+from typing import Any
+
+import json5
+from aiohttp import ClientError, ClientSession
+from astrbot.api import logger
+
+from .cookie import CookieJar
+
+
+@dataclass(slots=True, frozen=True)
+class SnowLumaCredentials:
+    """SnowLuma ``get_credentials`` 返回的 QQ Web 凭证。"""
+
+    cookies: str
+    token: int = 0
+    csrf_token: int = 0
+
+
+@dataclass(slots=True, frozen=True)
+class QZoneAuth:
+    """调用 QQ 空间 CGI 所需的登录态。"""
+
+    uin_cookie: str
+    uin: str
+    p_skey: str
+    gtk: int
+
+
+@dataclass(slots=True)
+class QZoneMediaDetail:
+    """浮层接口返回的一项媒体详情。"""
+
+    pic_key: str | None = None
+    raw_url: str | None = None
+    url: str | None = None
+    preview_url: str | None = None
+    is_video: bool = False
+    video_download_url: str | None = None
+    video_play_url: str | None = None
+    video_cover_url: str | None = None
+    video_duration: float = 0.0
+
+    @property
+    def best_image_url(self) -> str | None:
+        return self.raw_url or self.url or self.preview_url
+
+    @property
+    def best_video_url(self) -> str | None:
+        return self.video_download_url or self.video_play_url
+
+
+def qzone_gtk(p_skey: str) -> int:
+    """QQ 空间 hash33/g_tk。"""
+    value = 5381
+    for char in p_skey:
+        value += (value << 5) + ord(char)
+    return value & 0x7FFFFFFF
+
+
+def _raw_uin(value: str) -> str:
+    value = str(value or "").strip()
+    return value[1:] if value.startswith("o") else value
+
+
+def _first_string(mapping: dict[str, Any] | None, *keys: str) -> str | None:
+    if not isinstance(mapping, dict):
+        return None
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _parse_cookie_header(value: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in str(value or "").replace("\r", "").replace("\n", "").split(";"):
+        item = item.strip()
+        if not item or "=" not in item:
+            continue
+        name, cookie_value = item.split("=", 1)
+        name = name.strip()
+        if name:
+            result[name] = cookie_value.strip()
+    return result
+
+
+class SnowLumaCredentialProvider:
+    """通过 SnowLuma OneBot HTTP API 动态获取 qzone.qq.com Cookie。
+
+    Provider 只在内存中缓存短时间凭证。强制刷新时会重新请求 SnowLuma，
+    由 SnowLuma 使用当前已登录 QQ 的 clientKey / PSKey 链路生成最新凭证。
+    """
+
+    def __init__(
+        self,
+        session: ClientSession,
+        *,
+        base_url: str,
+        access_token: str = "",
+        cache_seconds: int = 300,
+    ) -> None:
+        self.session = session
+        self.base_url = str(base_url or "").strip().rstrip("/")
+        self.access_token = str(access_token or "").strip()
+        self.cache_seconds = max(0, int(cache_seconds or 0))
+        self._cached: SnowLumaCredentials | None = None
+        self._cached_at = 0.0
+        self._lock = asyncio.Lock()
+        self.last_error = ""
+
+    @property
+    def enabled(self) -> bool:
+        return self.base_url.startswith(("http://", "https://"))
+
+    def invalidate(self) -> None:
+        self._cached = None
+        self._cached_at = 0.0
+
+    def _cache_valid(self) -> bool:
+        if self._cached is None:
+            return False
+        if self.cache_seconds <= 0:
+            return False
+        return (time.monotonic() - self._cached_at) < self.cache_seconds
+
+    async def get(self, *, force: bool = False) -> SnowLumaCredentials | None:
+        if not self.enabled:
+            return None
+        if not force and self._cache_valid():
+            return self._cached
+
+        async with self._lock:
+            if not force and self._cache_valid():
+                return self._cached
+            credentials = await self._fetch()
+            if credentials is not None:
+                self._cached = credentials
+                self._cached_at = time.monotonic()
+                self.last_error = ""
+            elif force:
+                self.invalidate()
+            return credentials
+
+    async def _fetch(self) -> SnowLumaCredentials | None:
+        url = f"{self.base_url}/get_credentials"
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+
+        try:
+            # 本地 SnowLuma HTTP 不继承万能解析器的媒体代理设置。
+            async with self.session.post(
+                url,
+                json={"domain": "qzone.qq.com"},
+                headers=headers,
+            ) as response:
+                if response.status >= 400:
+                    self.last_error = f"HTTP {response.status}"
+                    return None
+                payload = await response.json(content_type=None)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.last_error = type(exc).__name__
+            return None
+
+        if not isinstance(payload, dict):
+            self.last_error = "响应不是对象"
+            return None
+        if str(payload.get("status") or "").lower() in {"failed", "error"}:
+            self.last_error = str(payload.get("message") or payload.get("wording") or "调用失败")
+            return None
+        try:
+            retcode = int(payload.get("retcode", 0) or 0)
+        except (TypeError, ValueError):
+            retcode = -1
+        if retcode != 0:
+            self.last_error = str(payload.get("message") or payload.get("wording") or f"retcode={retcode}")
+            return None
+
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+        cookies = str(data.get("cookies") or "").strip()
+        cookie_map = _parse_cookie_header(cookies)
+        if not cookie_map.get("p_skey") or not (cookie_map.get("uin") or cookie_map.get("p_uin")):
+            self.last_error = "返回 Cookie 缺少 uin/p_uin 或 p_skey"
+            return None
+
+        def as_int(value: Any) -> int:
+            try:
+                return int(value or 0)
+            except (TypeError, ValueError, OverflowError):
+                return 0
+
+        return SnowLumaCredentials(
+            cookies=cookies,
+            token=as_int(data.get("token")),
+            csrf_token=as_int(data.get("csrf_token")),
+        )
+
+
+class QZoneApiClient:
+    """只读 QQ 空间媒体详情客户端。"""
+
+    FLOATVIEW_URL = (
+        "https://user.qzone.qq.com/proxy/domain/photo.qzone.qq.com/"
+        "fcgi-bin/cgi_floatview_photo_list_v2"
+    )
+    PICFEED_URL = (
+        "https://user.qzone.qq.com/proxy/domain/ic2.qzone.qq.com/cgi-bin/feeds/"
+        "feeds2_html_picfeed_qqtab"
+    )
+
+    def __init__(
+        self,
+        session: ClientSession,
+        cookie_jar: CookieJar | None,
+        *,
+        proxy: str | None = None,
+        credential_provider: SnowLumaCredentialProvider | None = None,
+    ) -> None:
+        self.session = session
+        self.cookie_jar = cookie_jar
+        self.proxy = proxy
+        self.credential_provider = credential_provider
+        self._runtime_cookies: dict[str, str] = {}
+        self._runtime_gtk = 0
+        self._credential_source = "manual"
+
+    @property
+    def credential_source(self) -> str:
+        return self._credential_source
+
+    async def ensure_auth(self, *, force_refresh: bool = False) -> bool:
+        """确保存在可用登录态；SnowLuma 失败时保留手动 Cookie fallback。"""
+        provider = self.credential_provider
+        if provider is not None and provider.enabled:
+            credentials = await provider.get(force=force_refresh)
+            if credentials is not None:
+                self._runtime_cookies = _parse_cookie_header(credentials.cookies)
+                self._runtime_gtk = credentials.csrf_token or credentials.token
+                self._credential_source = "snowluma"
+                return self.auth() is not None
+            if force_refresh:
+                self._runtime_cookies = {}
+                self._runtime_gtk = 0
+
+        if self._manual_auth() is not None:
+            self._credential_source = "manual"
+            return True
+        return False
+
+    def _manual_auth(self) -> QZoneAuth | None:
+        if self.cookie_jar is None:
+            return None
+        cookies = self.cookie_jar.get(domain="user.qzone.qq.com")
+        p_skey = str(cookies.get("p_skey") or "").strip()
+        uin_cookie = str(cookies.get("uin") or cookies.get("p_uin") or "").strip()
+        uin = _raw_uin(uin_cookie)
+        if not uin or not p_skey:
+            return None
+        return QZoneAuth(
+            uin_cookie=uin_cookie,
+            uin=uin,
+            p_skey=p_skey,
+            gtk=qzone_gtk(p_skey),
+        )
+
+    def auth(self) -> QZoneAuth | None:
+        cookies = self._runtime_cookies
+        p_skey = str(cookies.get("p_skey") or "").strip()
+        uin_cookie = str(cookies.get("uin") or cookies.get("p_uin") or "").strip()
+        uin = _raw_uin(uin_cookie)
+        if uin and p_skey:
+            return QZoneAuth(
+                uin_cookie=uin_cookie,
+                uin=uin,
+                p_skey=p_skey,
+                gtk=self._runtime_gtk or qzone_gtk(p_skey),
+            )
+        return self._manual_auth()
+
+    @property
+    def available(self) -> bool:
+        return self.auth() is not None
+
+    def _cookie_header(self) -> str:
+        # 手动 Cookie / qq_photo_key 作为底层，SnowLuma 最新登录态覆盖同名项。
+        merged: dict[str, str] = {}
+        if self.cookie_jar is not None:
+            merged.update(self.cookie_jar.get(domain="user.qzone.qq.com"))
+        merged.update(self._runtime_cookies)
+        return "; ".join(f"{key}={value}" for key, value in merged.items())
+
+    def api_headers(self, referer: str = "https://user.qzone.qq.com/") -> dict[str, str]:
+        headers = {
+            "Referer": referer,
+            "Origin": "https://user.qzone.qq.com",
+            "Accept": "application/json,text/javascript,*/*;q=0.8",
+        }
+        if cookie := self._cookie_header():
+            headers["Cookie"] = cookie
+        return headers
+
+    def media_headers(self, referer: str = "https://user.qzone.qq.com/") -> dict[str, str]:
+        headers = {
+            "Referer": referer,
+            "Origin": "https://user.qzone.qq.com",
+            "Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+        }
+        if cookie := self._cookie_header():
+            headers["Cookie"] = cookie
+        return headers
+
+    def _update_cookies(self, response: Any) -> None:
+        if self.cookie_jar is None:
+            return
+        try:
+            values = response.headers.getall("Set-Cookie", [])
+        except Exception:
+            values = []
+        if values:
+            self.cookie_jar.update_from_response(list(values))
+
+    @staticmethod
+    def _normalize_duration(value: Any) -> float:
+        try:
+            duration = float(value or 0)
+        except (TypeError, ValueError, OverflowError):
+            return 0.0
+        if duration < 0:
+            return 0.0
+        if duration > 24 * 60 * 60:
+            duration /= 1000
+        return duration
+
+    @classmethod
+    def _detail_from_photo(cls, photo: dict[str, Any]) -> QZoneMediaDetail:
+        video_info = photo.get("video_info")
+        if not isinstance(video_info, dict):
+            video_info = {}
+
+        is_video = bool(photo.get("is_video"))
+        return QZoneMediaDetail(
+            pic_key=_first_string(photo, "picKey", "pic_key", "lloc", "id"),
+            raw_url=_first_string(photo, "raw", "raw_url", "origin", "origin_url"),
+            url=_first_string(photo, "url", "big_url", "large_url"),
+            preview_url=_first_string(photo, "pre", "preview", "thumb", "thumb_url"),
+            is_video=is_video,
+            video_download_url=_first_string(
+                video_info, "download_url", "downloadUrl", "raw_url"
+            ),
+            video_play_url=_first_string(video_info, "video_url", "videoUrl", "url"),
+            video_cover_url=(
+                _first_string(video_info, "cover_url", "cover", "pic_url")
+                or _first_string(photo, "pre", "url")
+            ),
+            video_duration=cls._normalize_duration(
+                video_info.get("duration")
+                or video_info.get("video_time")
+                or photo.get("videotime")
+            ),
+        )
+
+    @staticmethod
+    async def _read_object_response(response: Any) -> dict[str, Any] | None:
+        text = await response.text()
+        stripped = text.strip()
+        if not stripped:
+            return None
+        try:
+            value = json.loads(stripped)
+            return value if isinstance(value, dict) else None
+        except (json.JSONDecodeError, TypeError):
+            try:
+                value = json5.loads(stripped)
+                return value if isinstance(value, dict) else None
+            except (ValueError, TypeError):
+                pass
+
+        left = stripped.find("(")
+        right = stripped.rfind(")")
+        if left >= 0 and right > left:
+            inner = stripped[left + 1 : right].strip()
+            try:
+                value = json.loads(inner)
+                return value if isinstance(value, dict) else None
+            except (json.JSONDecodeError, TypeError):
+                try:
+                    value = json5.loads(inner)
+                    return value if isinstance(value, dict) else None
+                except (ValueError, TypeError):
+                    return None
+        return None
+
+    @staticmethod
+    def _looks_like_auth_failure(payload: dict[str, Any] | None, status: int = 200) -> bool:
+        if status in {401, 403}:
+            return True
+        if not isinstance(payload, dict):
+            return True
+        message = " ".join(
+            str(payload.get(key) or "")
+            for key in ("message", "msg", "wording", "error", "em")
+        ).lower()
+        if any(
+            token in message
+            for token in (
+                "login",
+                "not logged",
+                "skey",
+                "p_skey",
+                "cookie",
+                "登录",
+                "未登录",
+                "登陆",
+                "凭证",
+                "鉴权",
+            )
+        ):
+            return True
+        try:
+            code = int(payload.get("code", payload.get("ret", 0)) or 0)
+        except (TypeError, ValueError):
+            code = 0
+        # QQ 空间 Web CGI 常见“需要登录/登录态失效”返回值。
+        return code == -3000
+
+    async def _maybe_refresh_after_failure(
+        self, payload: dict[str, Any] | None, status: int
+    ) -> bool:
+        provider = self.credential_provider
+        if provider is None or not provider.enabled:
+            return False
+        if not self._looks_like_auth_failure(payload, status):
+            return False
+        provider.invalidate()
+        refreshed = await self.ensure_auth(force_refresh=True)
+        if refreshed:
+            logger.info("[QZone] SnowLuma 凭证已刷新，正在重试 QQ 空间媒体接口")
+        return refreshed
+
+    async def get_photo_feed(
+        self,
+        *,
+        host_uin: str,
+        begintime: int = 0,
+    ) -> dict[str, Any] | None:
+        """读取照片/视频动态流的一页。"""
+        host_uin = _raw_uin(host_uin)
+        if not host_uin:
+            return None
+
+        for attempt in range(2):
+            if not await self.ensure_auth(force_refresh=False):
+                return None
+            auth = self.auth()
+            if auth is None:
+                return None
+            params = {
+                "g_tk": auth.gtk,
+                "t": int(time.time() * 1000),
+                "uin": auth.uin,
+                "hostUin": host_uin,
+                "fuin": host_uin,
+                "appid": 4,
+                "inCharset": "utf-8",
+                "outCharset": "utf-8",
+                "begintime": max(0, int(begintime or 0)),
+            }
+            try:
+                async with self.session.get(
+                    self.PICFEED_URL,
+                    params=params,
+                    headers=self.api_headers(f"https://user.qzone.qq.com/{host_uin}/main"),
+                    proxy=self.proxy,
+                ) as response:
+                    self._update_cookies(response)
+                    status = response.status
+                    if status >= 400:
+                        payload = None
+                    else:
+                        payload = await self._read_object_response(response)
+            except asyncio.CancelledError:
+                raise
+            except (ClientError, ValueError, TypeError):
+                return None
+
+            if attempt == 0 and await self._maybe_refresh_after_failure(payload, status):
+                continue
+            return payload if status < 400 else None
+        return None
+
+    @staticmethod
+    def find_feed(
+        payload: dict[str, Any] | None,
+        *,
+        cell_id: str = "",
+        timestamp: int | None = None,
+    ) -> dict[str, Any] | None:
+        if not isinstance(payload, dict):
+            return None
+        data = payload.get("data")
+        feeds = data.get("feeds") if isinstance(data, dict) else None
+        if not isinstance(feeds, list):
+            return None
+
+        normalized_cell = str(cell_id or "").strip()
+        target_time = int(timestamp or 0)
+        if normalized_cell:
+            for feed in feeds:
+                if not isinstance(feed, dict):
+                    continue
+                keys = (feed.get("skey"), feed.get("cellid"), feed.get("tid"), feed.get("id"))
+                if any(str(value or "") == normalized_cell for value in keys):
+                    return feed
+        if target_time:
+            for feed in feeds:
+                if not isinstance(feed, dict):
+                    continue
+                try:
+                    feed_time = int(feed.get("time") or feed.get("abstime") or 0)
+                except (TypeError, ValueError):
+                    continue
+                if feed_time == target_time:
+                    return feed
+        return None
+
+    async def get_media_detail(
+        self,
+        *,
+        host_uin: str,
+        topic_id: str,
+        pic_key: str,
+    ) -> QZoneMediaDetail | None:
+        """通过 floatview 精确读取单个照片/视频详情。"""
+        if not host_uin or not topic_id or not pic_key:
+            return None
+
+        payload: dict[str, Any] | None = None
+        for attempt in range(2):
+            if not await self.ensure_auth(force_refresh=False):
+                return None
+            auth = self.auth()
+            if auth is None:
+                return None
+            params = {
+                "g_tk": auth.gtk,
+                "topicId": topic_id,
+                "picKey": pic_key,
+                "cmtNum": 0,
+                "inCharset": "utf-8",
+                "outCharset": "utf-8",
+                "uin": auth.uin,
+                "hostUin": _raw_uin(host_uin),
+                "appid": 4,
+                "isFirst": 1,
+                "postNum": 18,
+            }
+            try:
+                async with self.session.get(
+                    self.FLOATVIEW_URL,
+                    params=params,
+                    headers=self.api_headers(f"https://user.qzone.qq.com/{_raw_uin(host_uin)}"),
+                    proxy=self.proxy,
+                ) as response:
+                    self._update_cookies(response)
+                    status = response.status
+                    if status >= 400:
+                        payload = None
+                    else:
+                        payload = await self._read_object_response(response)
+            except asyncio.CancelledError:
+                raise
+            except (ClientError, ValueError, TypeError):
+                return None
+
+            if attempt == 0 and await self._maybe_refresh_after_failure(payload, status):
+                continue
+            if status >= 400:
+                return None
+            break
+
+        data = payload.get("data") if isinstance(payload, dict) else None
+        photos = data.get("photos") if isinstance(data, dict) else None
+        if not isinstance(photos, list) or not photos:
+            return None
+
+        matched: dict[str, Any] | None = None
+        for photo in photos:
+            if not isinstance(photo, dict):
+                continue
+            candidate = _first_string(photo, "picKey", "pic_key", "lloc", "id")
+            if candidate == pic_key:
+                matched = photo
+                break
+        if matched is None:
+            valid_photos = [p for p in photos if isinstance(p, dict)]
+            if len(valid_photos) == 1:
+                matched = valid_photos[0]
+        return self._detail_from_photo(matched) if matched else None
+
+
+__all__ = [
+    "QZoneApiClient",
+    "QZoneAuth",
+    "QZoneMediaDetail",
+    "SnowLumaCredentialProvider",
+    "SnowLumaCredentials",
+    "qzone_gtk",
+]

--- a/core/qzone_link.py
+++ b/core/qzone_link.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import TypedDict
+from urllib.parse import urljoin
+
+from aiohttp import (
+    ClientError,
+    ClientSession,
+    ClientTimeout,
+    DummyCookieJar,
+    TCPConnector,
+)
+from aiohttp.abc import AbstractResolver
+from aiohttp.resolver import DefaultResolver
+from yarl import URL
+
+
+MAX_BODY_BYTES = 128 * 1024
+MAX_REDIRECTS = 5
+FETCH_TIMEOUT = 5
+REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+
+_REQUEST_HEADERS = {
+    "User-Agent": "AstrBot-QZone-Link-Preview/1.0",
+    "Accept": "text/html,application/xhtml+xml",
+    "Accept-Encoding": "identity",
+}
+_HTML_CONTENT_TYPES = {"text/html", "application/xhtml+xml"}
+
+_IPV4_DENY_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in (
+        "0.0.0.0/8",
+        "10.0.0.0/8",
+        "100.64.0.0/10",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.0.0.0/24",
+        "192.0.2.0/24",
+        "192.31.196.0/24",
+        "192.52.193.0/24",
+        "192.88.99.0/24",
+        "192.168.0.0/16",
+        "192.175.48.0/24",
+        "198.18.0.0/15",
+        "198.51.100.0/24",
+        "203.0.113.0/24",
+        "224.0.0.0/4",
+        "240.0.0.0/4",
+    )
+)
+_IPV6_GLOBAL_UNICAST = ipaddress.ip_network("2000::/3")
+_IPV6_DENY_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in (
+        "::/128",
+        "::1/128",
+        "64:ff9b::/96",
+        "64:ff9b:1::/48",
+        "100::/64",
+        "2001::/23",
+        "2001:db8::/32",
+        "2002::/16",
+        "3fff::/20",
+        "fc00::/7",
+        "fe80::/10",
+        "ff00::/8",
+    )
+)
+
+
+class _ResolveRecord(TypedDict):
+    hostname: str
+    host: str
+    port: int
+    family: int
+    proto: int
+    flags: int
+
+
+@dataclass(frozen=True, slots=True)
+class LinkPreview:
+    title: str
+    url: str
+
+
+class _TitleParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._in_title = False
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() == "title":
+            self._in_title = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self._parts.append(data)
+
+    @property
+    def title(self) -> str:
+        return " ".join("".join(self._parts).split())
+
+
+def _is_public_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    if isinstance(address, ipaddress.IPv4Address):
+        return not any(address in network for network in _IPV4_DENY_NETWORKS)
+
+    mapped_address = getattr(address, "ipv4_mapped", None)
+    if mapped_address is not None:
+        return _is_public_address(mapped_address)
+    return address in _IPV6_GLOBAL_UNICAST and not any(
+        address in network for network in _IPV6_DENY_NETWORKS
+    )
+
+
+class _SafeResolver(AbstractResolver):
+    def __init__(self, resolver: AbstractResolver | None = None) -> None:
+        self._resolver = resolver if resolver is not None else DefaultResolver()
+        self._closed = False
+
+    async def resolve(
+        self,
+        host: str,
+        port: int = 0,
+        family: int = socket.AF_INET,
+    ) -> list[_ResolveRecord]:
+        records = await self._resolver.resolve(host, port, family)
+        try:
+            if not records or not all(
+                _is_public_address(ipaddress.ip_address(record["host"]))
+                for record in records
+            ):
+                raise OSError("DNS did not resolve exclusively to public addresses")
+        except (KeyError, TypeError, ValueError, IndexError) as error:
+            raise OSError(
+                "DNS did not resolve exclusively to public addresses"
+            ) from error
+        return records
+
+    async def close(self) -> None:
+        if not self._closed:
+            await self._resolver.close()
+            self._closed = True
+
+
+def _is_safe_url(url: str) -> bool:
+    try:
+        parsed = URL(url)
+        if parsed.scheme.lower() not in {"http", "https"}:
+            return False
+        hostname = parsed.raw_host
+        if not hostname or parsed.user is not None or parsed.password is not None:
+            return False
+
+        parsed.port
+
+        try:
+            address = ipaddress.ip_address(hostname)
+        except ValueError:
+            try:
+                socket.inet_aton(hostname)
+            except (OSError, UnicodeError):
+                return True
+            return False
+        return _is_public_address(address)
+    except (UnicodeError, ValueError, TypeError):
+        return False
+
+
+def _hostname(url: str) -> str:
+    return URL(url).host or url
+
+
+def _html_title(body: bytes, charset: str | None) -> str:
+    try:
+        text = body[:MAX_BODY_BYTES].decode(charset or "utf-8", errors="replace")
+    except LookupError:
+        text = body[:MAX_BODY_BYTES].decode("utf-8", errors="replace")
+    parser = _TitleParser()
+    parser.feed(text)
+    return parser.title
+
+
+async def _read_bounded(content) -> bytes:
+    body = bytearray()
+    while len(body) < MAX_BODY_BYTES:
+        remaining = MAX_BODY_BYTES - len(body)
+        chunk = await content.read(remaining)
+        if not chunk:
+            break
+        body.extend(chunk[:remaining])
+    return bytes(body)
+
+
+async def _inspect_link(session, original_url: str) -> LinkPreview:
+    current_url = original_url
+    redirects_followed = 0
+
+    while True:
+        if not _is_safe_url(current_url):
+            return LinkPreview("访问失败", original_url)
+
+        async with session.get(
+            current_url,
+            allow_redirects=False,
+        ) as response:
+            if response.status in REDIRECT_STATUSES:
+                location = response.headers.get("Location")
+                if location is None or redirects_followed >= MAX_REDIRECTS:
+                    return LinkPreview(f"HTTP {response.status}", original_url)
+                current_url = urljoin(current_url, location)
+                redirects_followed += 1
+                continue
+
+            if not 200 <= response.status < 300:
+                return LinkPreview(f"HTTP {response.status}", original_url)
+
+            hostname = _hostname(current_url)
+            content_encoding = response.headers.get("Content-Encoding", "").strip()
+            if content_encoding and content_encoding.lower() != "identity":
+                return LinkPreview(hostname, original_url)
+            if response.content_type.lower() not in _HTML_CONTENT_TYPES:
+                return LinkPreview(hostname, original_url)
+
+            body = await _read_bounded(response.content)
+            return LinkPreview(
+                _html_title(body, response.charset) or hostname,
+                original_url,
+            )
+
+
+async def inspect_link(url: str) -> LinkPreview:
+    async def inspect_with_dedicated_session() -> LinkPreview:
+        resolver = _SafeResolver()
+        connector = None
+        try:
+            connector = TCPConnector(resolver=resolver)
+            async with ClientSession(
+                connector=connector,
+                headers=_REQUEST_HEADERS,
+                cookie_jar=DummyCookieJar(),
+                auto_decompress=False,
+                trust_env=False,
+                timeout=ClientTimeout(total=FETCH_TIMEOUT),
+            ) as session:
+                return await _inspect_link(session, url)
+        finally:
+            if connector is not None and not connector.closed:
+                await connector.close()
+            await resolver.close()
+
+    try:
+        return await asyncio.wait_for(
+            inspect_with_dedicated_session(),
+            timeout=FETCH_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        return LinkPreview("请求超时", url)
+    except (ClientError, LookupError, OSError, UnicodeError, ValueError):
+        return LinkPreview("访问失败", url)

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,10 +1,11 @@
 import asyncio
 import hashlib
 import json
+import re
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any, TypeVar
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from astrbot.api import logger
 
@@ -209,15 +210,26 @@ def generate_file_name(url: str, default_suffix: str = "") -> str:
     return file_name
 
 
+URL_RE = re.compile(r"https?://[^\s\"'<>\\]+")
+
+
+def _iter_json_string_values(obj: Any):
+    if isinstance(obj, dict):
+        for value in obj.values():
+            yield from _iter_json_string_values(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_json_string_values(item)
+    elif isinstance(obj, str):
+        yield obj
+
+
+def _clean_embedded_url(value: str) -> str:
+    return unquote(value.strip().replace("\\/", "/"))
+
+
 def extract_json_url(data: dict | str) -> str | None:
-    """处理 JSON 类型的消息段，提取 URL
-
-    Args:
-        data: JSON 类型的消息字典
-
-    Returns:
-        Optional[str]: 提取的 URL, 如果提取失败则返回 None
-    """
+    """处理 JSON 类型消息段，提取可交给解析器处理的 URL。"""
     if isinstance(data, str):
         try:
             data = json.loads(data)
@@ -227,16 +239,68 @@ def extract_json_url(data: dict | str) -> str | None:
     if not isinstance(data, dict):
         return None
 
-    meta: dict[str, Any] | None = data.get("meta")
-    if not meta:
+    meta = data.get("meta")
+    if not isinstance(meta, dict):
+        meta = {}
+
+    # 优先读取 QQ 卡片中明确表达跳转目标的字段。
+    priority_paths = (
+        ("miniapp", "legacyUrl"),
+        ("miniapp", "pcJumpUrl"),
+        ("miniapp", "jumpUrl"),
+        ("miniapp", "sourceUrl"),
+        ("miniapp", "url"),
+        ("detail_1", "qqdocurl"),
+        ("detail_1", "jumpUrl"),
+        ("detail_1", "url"),
+        ("detail_1", "sourceUrl"),
+        ("detail_1", "shareUrl"),
+        ("detail_1", "targetUrl"),
+        ("news", "jumpUrl"),
+        ("news", "url"),
+        ("news", "sourceUrl"),
+        ("news", "shareUrl"),
+        ("music", "musicUrl"),
+        ("music", "jumpUrl"),
+        ("music", "url"),
+    )
+    for key1, key2 in priority_paths:
+        node = meta.get(key1)
+        if not isinstance(node, dict):
+            continue
+        value = node.get(key2)
+        if not isinstance(value, str):
+            continue
+        match = URL_RE.search(_clean_embedded_url(value))
+        if match:
+            return match.group(0)
+
+    # 部分 OneBot/QQ 卡片会把真实 URL 藏在更深层字段中。
+    candidates: list[str] = []
+    for value in _iter_json_string_values(data):
+        cleaned = _clean_embedded_url(value)
+        candidates.extend(match.group(0) for match in URL_RE.finditer(cleaned))
+
+    if not candidates:
         return None
 
-    for key1, key2 in (
-        ("music", "musicUrl"),
-        ("detail_1", "qqdocurl"),
-        ("news", "jumpUrl"),
-        ("music", "jumpUrl"),
-    ):
-        if url := meta.get(key1, {}).get(key2):
-            return url
-    return None
+    # QZone 分享卡优先，之后保持常见分享短链优先级。
+    preferred_keywords = (
+        "mobile.qzone.qq.com/l",
+        "h5.qzone.qq.com/ugc/share",
+        "m.qzone.qq.com",
+        "user.qzone.qq.com",
+        "qzone.qq.com",
+        "b23.tv",
+        "bili2233.cn",
+        "bilibili.com",
+        "xhslink.cn",
+        "xhslink.com",
+        "xiaohongshu.com",
+    )
+    for keyword in preferred_keywords:
+        for url in candidates:
+            if keyword in url:
+                return url
+
+    return candidates[0]

--- a/main.py
+++ b/main.py
@@ -150,10 +150,15 @@ class ParserPlugin(Star):
         if mentioned_ids and self_id not in mentioned_ids:
             return
 
-        # 卡片解析：解析Json组件，提取URL
-        if isinstance(seg1, Json):
-            text = extract_json_url(seg1.data)
-            logger.debug(f"解析Json组件: {text}")
+        # 卡片解析：扫描整条消息链，兼容 @ + JSON 卡片等组合消息。
+        for seg in chain:
+            if not isinstance(seg, Json):
+                continue
+            parsed_url = extract_json_url(seg.data)
+            logger.debug(f"解析Json组件: {parsed_url}")
+            if parsed_url:
+                text = parsed_url
+                break
 
         # 引用解析
         reply_seg = next((seg for seg in chain if isinstance(seg, Reply)), None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ apilmoji[tqdm]>=0.3.0,<1.0.0
 bilibili-api-python>=17.4.1,<18.0.0
 yt-dlp[default]>=2025.12.8
 gallery-dl>=1.31.2
+json5>=0.9,<1.0

--- a/tests/test_json_url.py
+++ b/tests/test_json_url.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def utils_module(monkeypatch: pytest.MonkeyPatch):
+    logger = SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None)
+    astrbot_pkg = types.ModuleType("astrbot")
+    astrbot_pkg.__path__ = []
+    api_module = types.ModuleType("astrbot.api")
+    api_module.logger = logger
+    monkeypatch.setitem(sys.modules, "astrbot", astrbot_pkg)
+    monkeypatch.setitem(sys.modules, "astrbot.api", api_module)
+    monkeypatch.delitem(sys.modules, "core.utils", raising=False)
+    return importlib.import_module("core.utils")
+
+
+def test_extract_json_url_keeps_existing_detail_qqdocurl_support(utils_module):
+    data = {"meta": {"detail_1": {"qqdocurl": "https://example.com/doc"}}}
+    assert utils_module.extract_json_url(data) == "https://example.com/doc"
+
+
+def test_extract_json_url_reads_qzone_miniapp_legacy_url(utils_module):
+    data = {
+        "meta": {
+            "miniapp": {
+                "legacyUrl": "https%3A%2F%2Fh5.qzone.qq.com%2Fugc%2Fshare%2F%3Fsid%3Dabc"
+            }
+        }
+    }
+    assert utils_module.extract_json_url(data).startswith(
+        "https://h5.qzone.qq.com/ugc/share/?sid=abc"
+    )
+
+
+def test_extract_json_url_prefers_nested_qzone_share_over_unrelated_url(utils_module):
+    data = {
+        "prompt": "https://example.com/landing",
+        "meta": {
+            "detail": {
+                "nested": "open https:\\/\\/mobile.qzone.qq.com\\/l?g=123 now"
+            }
+        },
+    }
+    assert utils_module.extract_json_url(data) == "https://mobile.qzone.qq.com/l?g=123"

--- a/tests/test_qzone_api.py
+++ b/tests/test_qzone_api.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+class FakeResponse:
+    def __init__(self, *, status=200, payload=None, text=None, headers=None):
+        self.status = status
+        self._payload = payload
+        self._text = text
+        self.headers = headers or {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self, content_type=None):
+        return self._payload
+
+    async def text(self):
+        if self._text is not None:
+            return self._text
+        return ""
+
+
+class FakeSession:
+    def __init__(self, *, posts=None, gets=None):
+        self.posts = list(posts or [])
+        self.gets = list(gets or [])
+        self.post_calls = []
+        self.get_calls = []
+
+    def post(self, url, **kwargs):
+        self.post_calls.append((url, kwargs))
+        if not self.posts:
+            raise AssertionError("unexpected POST")
+        return self.posts.pop(0)
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        if not self.gets:
+            raise AssertionError("unexpected GET")
+        return self.gets.pop(0)
+
+
+class FakeCookieJar:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+        self.updated = []
+
+    def get(self, *, domain=None, path="/", secure=True):
+        return dict(self.values)
+
+    def get_cookie_header_for_url(self, url):
+        return "; ".join(f"{k}={v}" for k, v in self.values.items())
+
+    def update_from_response(self, values):
+        self.updated.extend(values)
+
+
+@pytest.fixture
+def qzone_api(monkeypatch: pytest.MonkeyPatch):
+    logger = SimpleNamespace(
+        debug=lambda *args, **kwargs: None,
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+    )
+    astrbot_pkg = types.ModuleType("astrbot")
+    astrbot_pkg.__path__ = []
+    api_module = types.ModuleType("astrbot.api")
+    api_module.logger = logger
+    monkeypatch.setitem(sys.modules, "astrbot", astrbot_pkg)
+    monkeypatch.setitem(sys.modules, "astrbot.api", api_module)
+
+    cookie_module = types.ModuleType("core.cookie")
+    cookie_module.CookieJar = FakeCookieJar
+    monkeypatch.setitem(sys.modules, "core.cookie", cookie_module)
+    monkeypatch.delitem(sys.modules, "core.qzone_api", raising=False)
+    return importlib.import_module("core.qzone_api")
+
+
+def test_qzone_gtk_matches_hash33(qzone_api):
+    assert qzone_api.qzone_gtk("abc") == 193485963
+
+
+@pytest.mark.asyncio
+async def test_snowluma_get_credentials_uses_domain_and_bearer_token(qzone_api):
+    response = FakeResponse(
+        payload={
+            "status": "ok",
+            "retcode": 0,
+            "data": {
+                "cookies": "uin=o12345; p_skey=fresh-pskey; skey=s",
+                "token": 11,
+                "csrf_token": 22,
+            },
+        }
+    )
+    session = FakeSession(posts=[response])
+    provider = qzone_api.SnowLumaCredentialProvider(
+        session,
+        base_url="http://127.0.0.1:3000/",
+        access_token="test-token",
+        cache_seconds=300,
+    )
+
+    credentials = await provider.get()
+
+    assert credentials.cookies.startswith("uin=o12345")
+    assert credentials.token == 11
+    assert credentials.csrf_token == 22
+    assert len(session.post_calls) == 1
+    url, kwargs = session.post_calls[0]
+    assert url == "http://127.0.0.1:3000/get_credentials"
+    assert kwargs["json"] == {"domain": "qzone.qq.com"}
+    assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+
+
+@pytest.mark.asyncio
+async def test_snowluma_credentials_are_cached_and_force_refreshable(qzone_api):
+    first = FakeResponse(
+        payload={"retcode": 0, "data": {"cookies": "uin=o1; p_skey=old"}}
+    )
+    second = FakeResponse(
+        payload={"retcode": 0, "data": {"cookies": "uin=o1; p_skey=new"}}
+    )
+    session = FakeSession(posts=[first, second])
+    provider = qzone_api.SnowLumaCredentialProvider(
+        session, base_url="http://127.0.0.1:3000", cache_seconds=300
+    )
+
+    assert (await provider.get()).cookies.endswith("p_skey=old")
+    assert (await provider.get()).cookies.endswith("p_skey=old")
+    assert len(session.post_calls) == 1
+
+    assert (await provider.get(force=True)).cookies.endswith("p_skey=new")
+    assert len(session.post_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_snowluma_invalid_credentials_fail_closed(qzone_api):
+    session = FakeSession(
+        posts=[FakeResponse(payload={"retcode": 0, "data": {"cookies": "uin=o1"}})]
+    )
+    provider = qzone_api.SnowLumaCredentialProvider(
+        session, base_url="http://127.0.0.1:3000"
+    )
+
+    assert await provider.get() is None
+    assert "p_skey" in provider.last_error
+
+
+def test_manual_cookie_auth_is_supported(qzone_api):
+    jar = FakeCookieJar({"uin": "o12345", "p_skey": "manual-key", "skey": "s"})
+    client = qzone_api.QZoneApiClient(FakeSession(), jar)
+
+    auth = client.auth()
+
+    assert auth is not None
+    assert auth.uin == "12345"
+    assert auth.uin_cookie == "o12345"
+    assert auth.p_skey == "manual-key"
+    assert auth.gtk == qzone_api.qzone_gtk("manual-key")
+
+
+def test_auth_failure_detection_handles_qzone_login_failures(qzone_api):
+    assert qzone_api.QZoneApiClient._looks_like_auth_failure({"code": -3000})
+    assert qzone_api.QZoneApiClient._looks_like_auth_failure({"message": "请先登录"})
+    assert qzone_api.QZoneApiClient._looks_like_auth_failure({}, 401)
+    assert not qzone_api.QZoneApiClient._looks_like_auth_failure({"code": 0, "data": {}})
+
+
+@pytest.mark.asyncio
+async def test_object_response_supports_json5_callback(qzone_api):
+    response = FakeResponse(text="callback({code: 0, data: {name: 'ok'}})")
+
+    payload = await qzone_api.QZoneApiClient._read_object_response(response)
+
+    assert payload == {"code": 0, "data": {"name": "ok"}}
+
+
+@pytest.mark.asyncio
+async def test_api_refreshes_snowluma_once_after_minus_3000(qzone_api):
+    class Provider:
+        enabled = True
+
+        def __init__(self):
+            self.calls = []
+            self.invalidated = 0
+
+        async def get(self, *, force=False):
+            self.calls.append(force)
+            key = "new" if force else "old"
+            return qzone_api.SnowLumaCredentials(
+                cookies=f"uin=o123; p_skey={key}",
+                csrf_token=99 if force else 88,
+            )
+
+        def invalidate(self):
+            self.invalidated += 1
+
+    session = FakeSession(
+        gets=[
+            FakeResponse(text='{"code": -3000, "message": "请先登录"}'),
+            FakeResponse(text='{"code": 0, "data": {"feeds": []}}'),
+        ]
+    )
+    provider = Provider()
+    client = qzone_api.QZoneApiClient(
+        session, None, credential_provider=provider
+    )
+
+    payload = await client.get_photo_feed(host_uin="123")
+
+    assert payload["code"] == 0
+    assert provider.invalidated == 1
+    assert provider.calls == [False, True, False]
+    assert len(session.get_calls) == 2

--- a/tests/test_qzone_link.py
+++ b/tests/test_qzone_link.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from core.qzone_link import _is_safe_url
+
+
+def test_qzone_blue_link_ssrf_filter_allows_public_http_urls():
+    assert _is_safe_url("https://example.com/path")
+    assert _is_safe_url("http://8.8.8.8/")
+
+
+def test_qzone_blue_link_ssrf_filter_blocks_local_and_non_http_urls():
+    assert not _is_safe_url("http://127.0.0.1/admin")
+    assert not _is_safe_url("http://10.0.0.1/")
+    assert not _is_safe_url("http://[::1]/")
+    assert not _is_safe_url("file:///etc/passwd")
+    assert not _is_safe_url("https://user:pass@example.com/")


### PR DESCRIPTION
## Summary

新增 QQ 空间公开分享解析器，支持公开动态中的文本、图片和视频，并优先解析原始图片/原始视频资源。

QQ 空间登录态增强是可选能力：默认可在无登录态时使用公开 H5 分享页；配置后可通过手动 Cookie，或通过 SnowLuma OneBot HTTP `get_credentials(domain=qzone.qq.com)` 动态获取当前机器人 QQ 的 Web 凭证。（理论上napcat的api也可以但我没做测试）

## Features

- 支持 QQ 空间公开分享链接：
  - `h5.qzone.qq.com/ugc/share`
  - `mobile.qzone.qq.com/l`
- 支持 QQ JSON 分享卡片中的 QZone URL 提取。
- 解析作者、正文、发布时间、图片和视频。
- 图片优先使用 QQ 空间 API 返回的 raw / original / big media URL，失败时回退公开分享页资源。
- 视频优先使用媒体详情中的 download/play URL，失败时回退公开分享页视频。
- 可选解析动态正文中的外部链接标题；链接预览使用 SSRF 防护，仅访问公共 HTTP/HTTPS 地址。

## Optional SnowLuma authentication

SnowLuma **不是强制依赖**。

登录态优先级：

1. SnowLuma OneBot `get_credentials(domain=qzone.qq.com)`
2. 手动配置 QQ 空间 Cookie
3. 公开 H5 分享页 fallback

SnowLuma 凭证会短时缓存。QQ 空间 CGI 返回登录态异常时，会清除缓存、重新获取一次凭证并自动重试；SnowLuma 不可用时仍可回退手动 Cookie / 公开 H5。

## Security / scope

- 不记录 SnowLuma access token、Cookie、`p_skey` 或媒体签名 URL。
- SnowLuma 只作为当前已登录 QQ 的凭证提供器；QQ 本体掉线时仍需恢复 QQ 登录。
- 登录态仅用于读取当前分享动态相关媒体详情，不用于绕过 QQ 空间自身访问权限。
- 外部蓝链预览禁止 localhost、私网、链路本地、保留地址、非 HTTP(S) scheme 和带 userinfo 的 URL。

## Compatibility

- QQ 空间解析器作为可选 parser template 提供，默认不自动加入现有 `default_template.json`，避免改变已有用户行为。
- 现有平台解析逻辑保持不变。

## Tests

```text
python -m pytest -q
33 passed

python -m compileall -q main.py core
passed

python -m json.tool _conf_schema.json
passed

git diff --check
passed
```

## Implementation note

QQ 空间 Web CGI 行为基于公开网页请求进行独立实现；未 vendoring 或复制 QzonePhoto 的 GPL 源码。

## 参考与致谢

QQ 空间原图 / 原视频解析过程中参考了开源项目
QzonePhoto（https://github.com/11273/QzonePhoto）
对 QQ 空间网页接口和媒体资源获取流程的研究成果。

本 PR 未直接复制或引入 QzonePhoto 的源码，
相关逻辑为根据接口行为重新独立实现。

## Summary by Sourcery

添加一个可选的 QQ空间（QZone）公开分享解析器，支持原始媒体分辨率和安全链接预览，并包含相关配置、工具方法和测试。

New Features:
- 引入 QQ空间 解析器，处理公开分享链接和 JSON 分享卡片，提取作者、文本、图片和视频，并优先使用媒体的原始 URL。
- 新增可选的基于 SnowLuma 的 QQ Web 凭证集成，并在无法使用时回退到手动 Cookie 与公开 H5 页面来访问 QZone 媒体 API。
- 为嵌入在 QQ空间帖子文本中的 URL 提供防 SSRF 的外部链接预览支持。

Bug Fixes:
- 改进 JSON 分享卡片的 URL 提取逻辑，更好地处理嵌套字段，并优先识别常见平台和 QZone 相关的 URL。
- 更新消息处理逻辑，扫描整个消息链中的 JSON 卡片片段，确保在包含 @ 和卡片混合的消息中也能正确选择 URL。

Enhancements:
- 增强媒体请求头和 Cookie 管理，以支持基于 QZone API 的图片和视频获取，同时在这些能力不可用时保持现有行为不变。

Build:
- 添加 `json5` 作为依赖，用于解析来自 QZone API 的非标准 JSON 响应。

Documentation:
- 在 README 中记录 QQ空间 解析器的能力、登录选项以及 SnowLuma HTTP 配置。

Tests:
- 添加针对 QZone API 客户端行为的单元测试，包括 SnowLuma 凭证缓存和认证刷新逻辑。
- 添加 JSON URL 提取测试，覆盖 QZone 特定字段和嵌套 URL 选择。
- 添加 QZone 链接安全过滤测试，用于验证蓝色链接预览上的 SSRF 防护。

Chores:
- 扩展解析器配置，加入 QQ空间 特定选项，如凭证来源和 SnowLuma 设置，并在解析器注册表中注册新的解析器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an optional QQ空间 (QZone) public share parser with original media resolution support and secure link previews, plus supporting config, utilities, and tests.

New Features:
- Introduce a QQ空间 parser that handles public share links and JSON share cards, extracting author, text, images, and video with preference for original media URLs.
- Add optional SnowLuma-based QQ Web credential integration with fallback to manual cookies and public H5 pages for QZone media APIs.
- Provide SSRF-safe external link preview support for URLs embedded in QQ空间 post text.

Bug Fixes:
- Improve JSON share card URL extraction to better handle nested fields and prioritize common platform and QZone URLs.
- Update message handling to scan the full message chain for JSON card segments, ensuring URLs are correctly picked even in mixed @ + card messages.

Enhancements:
- Enhance media header handling and cookie management to support QZone API-backed image and video retrieval while preserving existing behavior when unavailable.

Build:
- Add json5 as a dependency for parsing non-standard JSON responses from QZone APIs.

Documentation:
- Document the QQ空间 parser capabilities, login options, and SnowLuma HTTP configuration in the README.

Tests:
- Add unit tests for QZone API client behavior, including SnowLuma credential caching and auth refresh logic.
- Add tests for JSON URL extraction to cover QZone-specific fields and nested URL selection.
- Add tests for QZone link safety filtering to validate SSRF protections on blue link previews.

Chores:
- Extend parser configuration to include QQ空间-specific options such as credential sources and SnowLuma settings, and register the new parser in the parser registry.

</details>

## Summary by Sourcery

添加一个可选的 QQ空间公开分享解析器，支持原始媒体、安全的链接预览以及与 SnowLuma 集成的认证，同时更新配置、依赖和测试。

新特性：
- 添加一个 QQ空间公开分享解析器，可提取作者、文本、图片和视频，优先使用原始分辨率媒体，并支持可选的基于 SnowLuma 的认证以及手动 Cookie 回退。
- 为嵌入在 QQ空间帖子文本中的 URL 引入 SSRF 安全的外部链接预览，使用受约束的 HTTP 抓取器。

缺陷修复：
- 拓展 JSON 分享卡片 URL 的提取逻辑，以处理嵌套字段并优先识别 QZone 及其他常见平台的 URL，确保在完整消息链中都能找到 URL，包括混合 @ + 卡片消息。

改进：
- 通过专用的 QQ空间 API 客户端增强媒体请求头和 Cookie 处理，该客户端集成 SnowLuma 凭据和手动 Cookie，同时在不可用时保持原有行为不变。

构建：
- 添加 json5 作为依赖，用于解析来自 QQ空间 API 的非标准 JSON 响应。

文档：
- 在 README 中记录 QQ空间解析器的能力、登录选项以及 SnowLuma HTTP 配置。

测试：
- 添加针对 QQ空间 API 客户端凭据处理和媒体详情获取的单元测试。
- 添加针对 JSON URL 提取的测试，包括 QZone 特定字段和嵌套 URL。
- 添加涵盖 QQ空间链接安全过滤和链接预览行为的测试。

杂项：
- 扩展解析器配置和注册表，将 QQ空间解析器纳入其中，并提供凭据来源和 SnowLuma 设置的相关选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an optional QQ空间 public share parser with original-media support, secure link previews, and SnowLuma-integrated authentication, alongside config, dependency, and test updates.

New Features:
- Add a QQ空间 public share parser that extracts author, text, images, and videos, preferring original-resolution media and supporting optional SnowLuma-based authentication with manual cookie fallback.
- Introduce SSRF-safe external link preview for URLs embedded in QQ空间 post text using a constrained HTTP fetcher.

Bug Fixes:
- Broaden JSON share card URL extraction to handle nested fields and prioritize QZone and other common platform URLs, and ensure URLs are found across the full message chain including mixed @ + card messages.

Enhancements:
- Enhance media request header and cookie handling via a dedicated QQ空间 API client that integrates SnowLuma credentials and manual cookies while keeping behavior unchanged when unavailable.

Build:
- Add json5 as a dependency to parse non-standard JSON responses from QQ空间 APIs.

Documentation:
- Document QQ空间 parser capabilities, login options, and SnowLuma HTTP configuration in the README.

Tests:
- Add unit tests for QQ空间 API client credential handling and media detail fetching.
- Add tests for JSON URL extraction including QZone-specific fields and nested URLs.
- Add tests covering QQ空间 link safety filtering and link preview behavior.

Chores:
- Extend parser configuration and registry to include a QQ空间 parser with options for credential source and SnowLuma settings.

</details>