### PR TITLE
feat：新增 CPP 无差别同人站链接解析

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -691,6 +691,18 @@
                         "hint": "选填，登录后可解析展品图集（试阅）",
                         "type": "text",
                         "default": ""
+                    },
+                    "show_work_content": {
+                        "description": "显示图文正文",
+                        "hint": "文字类图文是否显示正文内容。关闭后文字类图文不展示正文。",
+                        "type": "bool",
+                        "default": false
+                    },
+                    "text_max_length": {
+                        "description": "文字类图文消息最大字数",
+                        "hint": "仅文字类图文生效：解析出的文本超过该字数会被截断。图片类图文不限制。0 或不填按默认 100 处理。",
+                        "type": "int",
+                        "default": 100
                     }
                 }
             }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -672,6 +672,27 @@
                         "default": 0
                     }
                 }
+            },
+            "allcpp": {
+                "name": "CPP无差别同人站解析器",
+                "items": {
+                    "enable": {
+                        "description": "启用",
+                        "type": "bool",
+                        "default": true
+                    },
+                    "use_proxy": {
+                        "description": "使用代理",
+                        "type": "bool",
+                        "default": false
+                    },
+                    "cookies": {
+                        "description": "Cookies",
+                        "hint": "选填，登录后可解析展品图集（试阅）",
+                        "type": "text",
+                        "default": ""
+                    }
+                }
             }
         }
     }

--- a/core/config.py
+++ b/core/config.py
@@ -174,6 +174,7 @@ class ParserItem(ConfigNode):
 
 class ParserConfig(ConfigNodeContainer):
     acfun: ParserItem
+    allcpp: ParserItem
     bilibili: ParserItem
     douyin: ParserItem
     instagram: ParserItem

--- a/core/config.py
+++ b/core/config.py
@@ -156,6 +156,8 @@ class ParserItem(ConfigNode):
     use_proxy: bool
     cookies: str | None
     show_body_text: bool | None
+    show_work_content: bool | None
+    text_max_length: int | None
     video_send_mode: str | None
     video_codec_list: list | None
     video_quality: str | None

--- a/core/parsers/__init__.py
+++ b/core/parsers/__init__.py
@@ -1,4 +1,5 @@
 from .acfun import AcfunParser
+from .allcpp import AllcppParser
 from .base import BaseParser
 from .bilibili import BilibiliParser
 from .douyin import DouyinParser
@@ -21,6 +22,7 @@ from .pixiv import PixivParser
 __all__ = [
     "BaseParser",
     "AcfunParser",
+    "AllcppParser",
     "BilibiliParser",
     "DouyinParser",
     "InstagramParser",

--- a/core/parsers/allcpp.py
+++ b/core/parsers/allcpp.py
@@ -256,6 +256,11 @@ class AllcppParser(BaseParser):
         if m := search(r"var IS_USER_TRUENAME=(\w+);", html_text):
             info["is_logged_in"] = m.group(1).lower() == "true"
 
+        # 展品级试阅外链（登录后页面脚本中的 shiyueUrl / otherUrl）。
+        info["external_links"].extend(
+            self._extract_trial_url_variables(html_text)
+        )
+
         # 封面（取原图 href，不含 OSS 压缩样式）
         if m := search(r'<a class="djs-info-cover"[^>]*href="([^"]+)"', html_text):
             info["cover"] = self._normalize_page_url(m.group(1))
@@ -299,8 +304,11 @@ class AllcppParser(BaseParser):
                 for u in findall(r'<img[^>]*src="([^"]+)"', detail_block)
                 if (url := self._build_content_pic_url(u))
             ]
-            info["external_links"] = self._extract_external_links(detail_block)
+            info["external_links"].extend(
+                self._extract_external_links(detail_block)
+            )
 
+        info["external_links"] = self._deduplicate_links(info["external_links"])
         return info
 
     @staticmethod
@@ -547,6 +555,15 @@ class AllcppParser(BaseParser):
             f"https:{url}" if url.startswith("//") else url for url in raw_links
         ]
         return AllcppParser._deduplicate_links(raw_links)
+
+    @staticmethod
+    def _extract_trial_url_variables(content: str) -> list[str]:
+        """提取展品详情页脚本注入的试阅外链变量。"""
+        values = findall(
+            r"(?:shiyueUrl|otherUrl)\s*[:=]\s*[\"']([^\"']+)[\"']",
+            unescape(content or ""),
+        )
+        return AllcppParser._deduplicate_links(values)
 
     @staticmethod
     def _deduplicate_links(links: list[str]) -> list[str]:

--- a/core/parsers/allcpp.py
+++ b/core/parsers/allcpp.py
@@ -1,0 +1,265 @@
+"""CPP 无差别同人站（allcpp.cn）展品解析器"""
+
+from html import unescape
+from re import DOTALL, Match, findall, search, sub
+from typing import Any, ClassVar
+
+from aiohttp import ClientError
+
+from ..config import PluginConfig
+from ..cookie import CookieJar
+from ..data import MediaContent, Platform, SendGroup, TextContent
+from ..download import Downloader
+from .base import BaseParser, handle
+
+# 图片 CDN，与页面 `getLookWebPicUrl()` 对应
+PIC_CDN = "https://imagecdn3.allcpp.cn"
+
+
+class AllcppParser(BaseParser):
+    """allcpp.cn（无差别同人站）展品解析器
+
+    展品详情页（/d/<id>.do）会服务端渲染标题、封面、标签、作者等信息；
+    图集（试阅）内容走 ``allcpp/doujinshi/contribute/getList.do`` 接口，
+    该接口需要登录，未配置 Cookie 时退化为仅返回封面。
+    """
+
+    platform: ClassVar[Platform] = Platform(
+        name="allcpp", display_name="CPP无差别同人站"
+    )
+
+    def __init__(self, config: PluginConfig, downloader: Downloader):
+        super().__init__(config, downloader)
+        self.mycfg = config.parser.allcpp
+        self.headers.update(
+            {
+                "accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,*/*;q=0.8"
+                ),
+                "referer": "https://www.allcpp.cn/",
+            }
+        )
+        self.cookiejar = CookieJar(config, self.mycfg, domain="allcpp.cn")
+        if self.cookiejar.cookies_str:
+            self.headers["cookie"] = self.cookiejar.cookies_str
+
+    # https://icp.red/WmBvrs8XK （短链，重定向到 allcpp 展品页）
+    @handle("icp.red", r"icp\.red/(?P<short_code>[A-Za-z0-9]+)")
+    async def _parse_short_link(self, searched: Match[str]):
+        url = f"https://icp.red/{searched.group('short_code')}"
+        return await self.parse_with_redirect(url)
+
+    @handle("allcpp.cn", r"allcpp\.cn/d/(?P<did>\d+)")
+    async def _parse(self, searched: Match[str]):
+        did = searched.group("did")
+        page_url = f"https://www.allcpp.cn/d/{did}.do"
+
+        html_text = await self._fetch_page(page_url)
+        info = self._parse_page(html_text)
+
+        title = info["title"] or f"展品 {did}"
+        author = self.create_author(info["author_name"]) if info["author_name"] else None
+
+        # 图集（试阅）需要登录，未登录时退化为仅封面；样图同样并入
+        gallery = self._extract_gallery_images(await self._fetch_gallery(did))
+        image_urls = self._collect_images(info["cover"], gallery + info["sample_images"])
+        image_contents: list[MediaContent] = (
+            self.create_image_contents(image_urls) if image_urls else []
+        )
+
+        text = self._build_text(info, title)
+        contents: list[MediaContent] = []
+        if text:
+            contents.append(TextContent(text))
+        contents.extend(image_contents)
+
+        send_groups: list[SendGroup] = []
+        if len(contents) >= self.cfg.forward_threshold:
+            # 达到阈值：整体一个 group，不设 force_merge，交由 sender 合并转发
+            send_groups.append(SendGroup(contents=contents))
+        else:
+            if text:
+                send_groups.append(
+                    SendGroup(contents=[TextContent(text)], force_merge=False)
+                )
+            for img in image_contents:
+                send_groups.append(SendGroup(contents=[img], force_merge=False))
+
+        return self.result(
+            title=title,
+            text=text,
+            author=author,
+            contents=contents,
+            send_groups=send_groups,
+            url=page_url,
+        )
+
+    async def _fetch_page(self, url: str) -> str:
+        """拉取展品详情页 HTML"""
+        async with self.session.get(url, headers=self.headers) as resp:
+            if resp.status >= 400:
+                raise ClientError(f"HTTP {resp.status} {resp.reason}")
+            return await resp.text()
+
+    async def _fetch_gallery(self, did: str) -> list[dict[str, Any]]:
+        """拉取展品试阅（图集）内容，失败或未登录时返回空列表"""
+        url = "https://www.allcpp.cn/allcpp/doujinshi/contribute/getList.do"
+        params = {"pageindex": 1, "pagesize": 20, "id": did, "_plat": "web"}
+        try:
+            async with self.session.get(
+                url, params=params, headers=self.headers
+            ) as resp:
+                if resp.status >= 400:
+                    return []
+                data = await resp.json()
+        except (ClientError, ValueError):
+            return []
+        return data if isinstance(data, list) else []
+
+    def _parse_page(self, html_text: str) -> dict[str, Any]:
+        """从详情页 HTML 提取公开信息"""
+        info: dict[str, Any] = {
+            "title": None,
+            "cover": None,
+            "tags": [],
+            "heat": None,
+            "status": None,
+            "author_name": None,
+            "detail_text": None,
+            "sample_images": [],
+            "is_logged_in": False,
+        }
+
+        # 标题
+        if m := search(r'<h1 class="djs-info-title">(.*?)</h1>', html_text, DOTALL):
+            info["title"] = self._clean_text(m.group(1))
+
+        # 登录态（IS_USER_TRUENAME=true 表示已登录且实名）
+        if m := search(r"var IS_USER_TRUENAME=(\w+);", html_text):
+            info["is_logged_in"] = m.group(1).lower() == "true"
+
+        # 封面（取原图 href，不含 OSS 压缩样式）
+        if m := search(r'<a class="djs-info-cover"[^>]*href="([^"]+)"', html_text):
+            info["cover"] = m.group(1).strip()
+
+        # 标签
+        if m := search(r'<ul class="djs-info-tag">(.*?)</ul>', html_text, DOTALL):
+            tags = [
+                self._clean_text(t)
+                for t in findall(r"<li[^>]*>(.*?)</li>", m.group(1), DOTALL)
+            ]
+            info["tags"] = [t for t in tags if t]
+
+        # 总热度
+        if m := search(r'class="djs-info-hot-txt">(.*?)</label>', html_text, DOTALL):
+            if span := search(r"<span>([^<]+)</span>", m.group(1)):
+                info["heat"] = span.group(1).strip()
+
+        # 状态（策划中 / 已发售 等）
+        if m := search(r'class="sell-url[^"]*"[^>]*>(.*?)</a>', html_text, DOTALL):
+            info["status"] = self._clean_text(m.group(1))
+
+        # 上传人信息（作者）
+        if m := search(r'<div id="djs-create-user">(.*?)</div>', html_text, DOTALL):
+            uploader_block = m.group(1)
+            if title_m := search(r'title="([^"]+)"', uploader_block):
+                info["author_name"] = title_m.group(1).strip()
+            elif label_m := search(r"<label[^>]*>(.*?)</label>", uploader_block, DOTALL):
+                info["author_name"] = self._clean_text(label_m.group(1))
+
+        # 展品详情（登录后才有）：文字描述 + 图集样图
+        if m := search(
+            r'<div class="djs-tab-box info[^"]*"[^>]*>(.*?)</div>',
+            html_text,
+            DOTALL,
+        ):
+            detail_block = m.group(1)
+            if p := search(r"<p[^>]*>(.*?)</p>", detail_block, DOTALL):
+                info["detail_text"] = self._clean_detail(p.group(1))
+            info["sample_images"] = [
+                u.split("?")[0]
+                for u in findall(r'<img[^>]*src="([^"]+)"', detail_block)
+            ]
+
+        return info
+
+    def _extract_gallery_images(self, data: list[dict[str, Any]]) -> list[str]:
+        """从试阅接口数据中提取图集图片 URL"""
+        images: list[str] = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            works = item.get("works")
+            if not isinstance(works, dict):
+                continue
+            pics = works.get("pics")
+            if not isinstance(pics, list):
+                continue
+            for p in pics:
+                if not isinstance(p, dict):
+                    continue
+                pic = p.get("pic")
+                pic_url = pic.get("picUrl") if isinstance(pic, dict) else None
+                if not pic_url:
+                    pic_url = p.get("picUrl")
+                url = self._build_pic_url(str(pic_url) if pic_url else "")
+                if url:
+                    images.append(url)
+        return images
+
+    @staticmethod
+    def _build_text(info: dict[str, Any], title: str) -> str | None:
+        parts: list[str] = []
+        if title:
+            parts.append(title)
+        if info.get("author_name"):
+            parts.append(f"作者：{info['author_name']}")
+        if info.get("tags"):
+            parts.append("标签：" + " · ".join(info["tags"]))
+        if info.get("heat"):
+            parts.append(f"总热度：{info['heat']}")
+        if info.get("status"):
+            parts.append(f"状态：{info['status']}")
+        if info.get("detail_text"):
+            parts.append(info["detail_text"])
+        if not info.get("is_logged_in"):
+            parts.append("（未登录，无法获取展品详情与图集，配置 Cookie 后可查看）")
+        return "\n".join(parts) if parts else None
+
+    @staticmethod
+    def _collect_images(cover: str | None, gallery: list[str]) -> list[str]:
+        """合并封面与图集，去重"""
+        images: list[str] = []
+        seen: set[str] = set()
+        for url in ([cover] if cover else []) + gallery:
+            key = url.split("?", 1)[0]
+            if key in seen:
+                continue
+            seen.add(key)
+            images.append(url)
+        return images
+
+    @staticmethod
+    def _build_pic_url(raw: str) -> str | None:
+        raw = (raw or "").strip()
+        if not raw:
+            return None
+        if raw.startswith("http"):
+            return raw
+        return f"{PIC_CDN}/upload/{raw.lstrip('/')}"
+
+    @staticmethod
+    def _clean_text(text: str) -> str:
+        text = unescape(text or "")
+        text = sub(r"\s+", " ", text)
+        return text.strip()
+
+    @staticmethod
+    def _clean_detail(text: str) -> str:
+        """清理展品详情文字：去 <img>、<br> 换行、去空白行"""
+        text = unescape(text or "")
+        text = sub(r"<img[^>]*>", "", text)
+        text = text.replace("<br>", "\n").replace("<br/>", "\n")
+        lines = [line.strip() for line in text.split("\n")]
+        return "\n".join(line for line in lines if line)

--- a/core/parsers/allcpp.py
+++ b/core/parsers/allcpp.py
@@ -4,7 +4,7 @@ import json
 from html import unescape
 from re import DOTALL, Match, findall, search, sub
 from typing import Any, ClassVar
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 from aiohttp import ClientError
 
@@ -70,7 +70,10 @@ class AllcppParser(BaseParser):
         author = self.create_author(info["author_name"]) if info["author_name"] else None
 
         # 图集（试阅）需要登录，未登录时退化为仅封面；样图同样并入
-        gallery = self._extract_gallery_images(await self._fetch_gallery(did))
+        gallery, external_links = self._extract_gallery_content(
+            await self._fetch_gallery(did)
+        )
+        info["external_links"].extend(external_links)
         public_image_urls = self._collect_images(info["cover"], [])
         protected_image_urls = self._collect_images(
             None, gallery + info["sample_images"]
@@ -241,6 +244,7 @@ class AllcppParser(BaseParser):
             "author_name": None,
             "detail_text": None,
             "sample_images": [],
+            "external_links": [],
             "is_logged_in": False,
         }
 
@@ -295,6 +299,7 @@ class AllcppParser(BaseParser):
                 for u in findall(r'<img[^>]*src="([^"]+)"', detail_block)
                 if (url := self._build_content_pic_url(u))
             ]
+            info["external_links"] = self._extract_external_links(detail_block)
 
         return info
 
@@ -375,15 +380,23 @@ class AllcppParser(BaseParser):
         """接口字段异常时降级为空对象，避免单个字段导致整个解析失败。"""
         return value if isinstance(value, dict) else {}
 
-    def _extract_gallery_images(self, data: list[dict[str, Any]]) -> list[str]:
-        """从试阅接口数据中提取图集图片 URL"""
+    def _extract_gallery_content(
+        self, data: list[dict[str, Any]]
+    ) -> tuple[list[str], list[str]]:
+        """从试阅接口数据中提取图片及图文试阅内的外部链接。"""
         images: list[str] = []
+        external_links: list[str] = []
         for item in data:
             if not isinstance(item, dict):
                 continue
             works = item.get("works")
             if not isinstance(works, dict):
                 continue
+
+            content = works.get("content")
+            if isinstance(content, str):
+                external_links.extend(self._extract_external_links(content))
+
             pics = works.get("pics")
             if not isinstance(pics, list):
                 continue
@@ -397,7 +410,7 @@ class AllcppParser(BaseParser):
                 url = self._build_pic_url(str(pic_url) if pic_url else "")
                 if url:
                     images.append(url)
-        return images
+        return images, self._deduplicate_links(external_links)
 
     @staticmethod
     def _build_text(info: dict[str, Any], title: str) -> str | None:
@@ -414,6 +427,8 @@ class AllcppParser(BaseParser):
             parts.append(f"状态：{info['status']}")
         if info.get("detail_text"):
             parts.append(info["detail_text"])
+        if links := info.get("external_links"):
+            parts.append("试阅外部链接：\n" + "\n".join(links))
         if not info.get("is_logged_in"):
             parts.append("（未登录，无法获取展品详情与图集，配置 Cookie 后可查看）")
         return "\n".join(parts) if parts else None
@@ -521,6 +536,37 @@ class AllcppParser(BaseParser):
             return None
         url = urljoin(SITE_BASE, value)
         return url if url.startswith(("http://", "https://")) else None
+
+    @staticmethod
+    def _extract_external_links(content: str) -> list[str]:
+        """提取试阅 HTML 中的外部 HTTP(S) 链接，忽略 AllCPP 站内地址。"""
+        raw_links = findall(
+            r"(?:https?:)?//[^\s<>\"']+", unescape(content or "")
+        )
+        raw_links = [
+            f"https:{url}" if url.startswith("//") else url for url in raw_links
+        ]
+        return AllcppParser._deduplicate_links(raw_links)
+
+    @staticmethod
+    def _deduplicate_links(links: list[str]) -> list[str]:
+        result: list[str] = []
+        seen: set[str] = set()
+        for raw in links:
+            url = raw.rstrip(".,;:!?)】）〉》")
+            parsed = urlsplit(url)
+            host = (parsed.hostname or "").lower()
+            if (
+                parsed.scheme not in ("http", "https")
+                or not host
+                or host == "allcpp.cn"
+                or host.endswith(".allcpp.cn")
+                or url in seen
+            ):
+                continue
+            seen.add(url)
+            result.append(url)
+        return result
 
     @staticmethod
     def _clean_text(text: str) -> str:

--- a/core/parsers/allcpp.py
+++ b/core/parsers/allcpp.py
@@ -1,5 +1,6 @@
 """CPP 无差别同人站（allcpp.cn）展品解析器"""
 
+import json
 from html import unescape
 from re import DOTALL, Match, findall, search, sub
 from typing import Any, ClassVar
@@ -10,18 +11,21 @@ from ..config import PluginConfig
 from ..cookie import CookieJar
 from ..data import MediaContent, Platform, SendGroup, TextContent
 from ..download import Downloader
-from .base import BaseParser, handle
+from .base import BaseParser, ParseException, handle
 
 # 图片 CDN，与页面 `getLookWebPicUrl()` 对应
 PIC_CDN = "https://imagecdn3.allcpp.cn"
 
 
 class AllcppParser(BaseParser):
-    """allcpp.cn（无差别同人站）展品解析器
+    """allcpp.cn（无差别同人站）解析器
 
     展品详情页（/d/<id>.do）会服务端渲染标题、封面、标签、作者等信息；
     图集（试阅）内容走 ``allcpp/doujinshi/contribute/getList.do`` 接口，
     该接口需要登录，未配置 Cookie 时退化为仅返回封面。
+
+    图文（后花园文章）详情页（/w/<id>.do）内容由前端通过
+    ``works.allcpp.cn/rest/works/<id>`` 接口异步加载，这里直接请求该接口。
     """
 
     platform: ClassVar[Platform] = Platform(
@@ -95,6 +99,52 @@ class AllcppParser(BaseParser):
             url=page_url,
         )
 
+    # https://www.allcpp.cn/w/<id>.do 图文（后花园文章）详情页
+    @handle("allcpp.cn/w/", r"allcpp\.cn/w/(?P<wid>\d+)")
+    async def _parse_work(self, searched: Match[str]):
+        wid = searched.group("wid")
+        page_url = f"https://www.allcpp.cn/w/{wid}.do"
+
+        info = self._parse_work_data(await self._fetch_work(wid))
+
+        title = info["title"] or f"图文 {wid}"
+        author = (
+            self.create_author(info["author_name"], avatar_url=info["author_avatar"])
+            if info["author_name"]
+            else None
+        )
+
+        image_urls = self._collect_images(None, info["pics"])
+        image_contents: list[MediaContent] = (
+            self.create_image_contents(image_urls) if image_urls else []
+        )
+
+        text = self._build_work_text(info, title)
+        contents: list[MediaContent] = []
+        if text:
+            contents.append(TextContent(text))
+        contents.extend(image_contents)
+
+        send_groups: list[SendGroup] = []
+        if len(contents) >= self.cfg.forward_threshold:
+            send_groups.append(SendGroup(contents=contents))
+        else:
+            if text:
+                send_groups.append(
+                    SendGroup(contents=[TextContent(text)], force_merge=False)
+                )
+            for img in image_contents:
+                send_groups.append(SendGroup(contents=[img], force_merge=False))
+
+        return self.result(
+            title=title,
+            text=text,
+            author=author,
+            contents=contents,
+            send_groups=send_groups,
+            url=page_url,
+        )
+
     async def _fetch_page(self, url: str) -> str:
         """拉取展品详情页 HTML"""
         async with self.session.get(url, headers=self.headers) as resp:
@@ -116,6 +166,21 @@ class AllcppParser(BaseParser):
         except (ClientError, ValueError):
             return []
         return data if isinstance(data, list) else []
+
+    async def _fetch_work(self, wid: str) -> dict[str, Any]:
+        """拉取图文（后花园文章）详情，接口在 works.allcpp.cn 子域"""
+        url = f"https://works.allcpp.cn/rest/works/{wid}"
+        try:
+            async with self.session.get(url, headers=self.headers) as resp:
+                if resp.status >= 400:
+                    raise ClientError(f"HTTP {resp.status} {resp.reason}")
+                text = await resp.text()
+                data = json.loads(text) if text.strip() else None
+        except (ClientError, ValueError):
+            raise ParseException(f"图文 {wid} 不存在或已删除")
+        if not isinstance(data, dict) or not data.get("id"):
+            raise ParseException(f"图文 {wid} 不存在或已删除")
+        return data
 
     def _parse_page(self, html_text: str) -> dict[str, Any]:
         """从详情页 HTML 提取公开信息"""
@@ -184,6 +249,74 @@ class AllcppParser(BaseParser):
 
         return info
 
+    @staticmethod
+    def _parse_work_data(work: dict[str, Any]) -> dict[str, Any]:
+        """从图文接口数据中提取展示信息"""
+        user = work.get("user") or {}
+        face = user.get("face") or {}
+
+        info: dict[str, Any] = {
+            "title": work.get("name"),
+            "author_name": user.get("nickname"),
+            "author_avatar": AllcppParser._build_face_url(face.get("picUrl")),
+            "theme": work.get("theme"),
+            "type_label": AllcppParser._work_type_label(work.get("type")),
+            "hot": work.get("hotCount"),
+            "tags": [],
+            "foreword": None,
+            "content": None,
+            "pics": [],
+        }
+
+        tags = work.get("tags")
+        if isinstance(tags, list):
+            info["tags"] = [
+                t.get("tag")
+                for t in tags
+                if isinstance(t, dict) and t.get("tag")
+            ]
+
+        foreword = work.get("foreword")
+        if isinstance(foreword, str) and foreword.strip():
+            info["foreword"] = AllcppParser._clean_detail(foreword)
+
+        content = work.get("content")
+        if isinstance(content, str) and content.strip():
+            info["pics"].extend(AllcppParser._extract_content_images(content))
+            info["content"] = AllcppParser._clean_detail(content)
+
+        pics = work.get("pics")
+        if isinstance(pics, list):
+            for p in pics:
+                if not isinstance(p, dict):
+                    continue
+                pic = p.get("pic")
+                pic_url = pic.get("picUrl") if isinstance(pic, dict) else None
+                url = AllcppParser._build_pic_url(str(pic_url) if pic_url else "")
+                if url:
+                    info["pics"].append(url)
+
+        return info
+
+    @staticmethod
+    def _work_type_label(work_type: Any) -> str | None:
+        """图文类型标签：0=图片，1=文字"""
+        if work_type == 0:
+            return "图片"
+        if work_type == 1:
+            return "文字"
+        return None
+
+    @staticmethod
+    def _extract_content_images(content: str) -> list[str]:
+        """提取图文正文内嵌的图片（/uupload/image/... 相对路径）"""
+        images: list[str] = []
+        for src in findall(r'<img[^>]*src="([^"]+)"', content):
+            url = AllcppParser._build_content_pic_url(src)
+            if url:
+                images.append(url)
+        return images
+
     def _extract_gallery_images(self, data: list[dict[str, Any]]) -> list[str]:
         """从试阅接口数据中提取图集图片 URL"""
         images: list[str] = []
@@ -228,6 +361,27 @@ class AllcppParser(BaseParser):
         return "\n".join(parts) if parts else None
 
     @staticmethod
+    def _build_work_text(info: dict[str, Any], title: str) -> str | None:
+        parts: list[str] = []
+        if title:
+            parts.append(title)
+        if info.get("author_name"):
+            parts.append(f"作者：{info['author_name']}")
+        if info.get("theme"):
+            parts.append(f"主题：{info['theme']}")
+        if info.get("type_label"):
+            parts.append(f"类型：{info['type_label']}")
+        if info.get("tags"):
+            parts.append("标签：" + " · ".join(info["tags"]))
+        if info.get("hot"):
+            parts.append(f"热度：{info['hot']}")
+        if info.get("foreword"):
+            parts.append(info["foreword"])
+        if info.get("content"):
+            parts.append(info["content"])
+        return "\n".join(parts) if parts else None
+
+    @staticmethod
     def _collect_images(cover: str | None, gallery: list[str]) -> list[str]:
         """合并封面与图集，去重"""
         images: list[str] = []
@@ -248,6 +402,26 @@ class AllcppParser(BaseParser):
         if raw.startswith("http"):
             return raw
         return f"{PIC_CDN}/upload/{raw.lstrip('/')}"
+
+    @staticmethod
+    def _build_face_url(raw: str) -> str | None:
+        """用户头像 URL（/face/ 目录）"""
+        raw = (raw or "").strip()
+        if not raw:
+            return None
+        if raw.startswith("http"):
+            return raw
+        return f"{PIC_CDN}/face/{raw.lstrip('/')}"
+
+    @staticmethod
+    def _build_content_pic_url(raw: str) -> str | None:
+        """正文内嵌图片 URL（/uupload/image/... 已含目录前缀）"""
+        raw = (raw or "").strip()
+        if not raw:
+            return None
+        if raw.startswith("http"):
+            return raw
+        return f"{PIC_CDN}/{raw.lstrip('/')}"
 
     @staticmethod
     def _clean_text(text: str) -> str:

--- a/core/parsers/allcpp.py
+++ b/core/parsers/allcpp.py
@@ -4,6 +4,7 @@ import json
 from html import unescape
 from re import DOTALL, Match, findall, search, sub
 from typing import Any, ClassVar
+from urllib.parse import urljoin
 
 from aiohttp import ClientError
 
@@ -15,6 +16,7 @@ from .base import BaseParser, ParseException, handle
 
 # 图片 CDN，与页面 `getLookWebPicUrl()` 对应
 PIC_CDN = "https://imagecdn3.allcpp.cn"
+SITE_BASE = "https://www.allcpp.cn/"
 
 
 class AllcppParser(BaseParser):
@@ -44,9 +46,11 @@ class AllcppParser(BaseParser):
                 "referer": "https://www.allcpp.cn/",
             }
         )
+        # 公开资源不携带 Cookie，避免把登录态暴露给不需要鉴权的请求。
+        self.auth_headers = self.headers.copy()
         self.cookiejar = CookieJar(config, self.mycfg, domain="allcpp.cn")
         if self.cookiejar.cookies_str:
-            self.headers["cookie"] = self.cookiejar.cookies_str
+            self.auth_headers["cookie"] = self.cookiejar.cookies_str
 
     # https://icp.red/WmBvrs8XK （短链，重定向到 allcpp 展品页）
     @handle("icp.red", r"icp\.red/(?P<short_code>[A-Za-z0-9]+)")
@@ -67,10 +71,32 @@ class AllcppParser(BaseParser):
 
         # 图集（试阅）需要登录，未登录时退化为仅封面；样图同样并入
         gallery = self._extract_gallery_images(await self._fetch_gallery(did))
-        image_urls = self._collect_images(info["cover"], gallery + info["sample_images"])
-        image_contents: list[MediaContent] = (
-            self.create_image_contents(image_urls) if image_urls else []
+        public_image_urls = self._collect_images(info["cover"], [])
+        protected_image_urls = self._collect_images(
+            None, gallery + info["sample_images"]
         )
+        public_keys = {url.split("?", 1)[0] for url in public_image_urls}
+        protected_image_urls = [
+            url
+            for url in protected_image_urls
+            if url.split("?", 1)[0] not in public_keys
+        ]
+
+        image_contents: list[MediaContent] = []
+        if public_image_urls:
+            image_contents.extend(
+                self.create_image_contents(
+                    public_image_urls,
+                    headers=self._image_headers(page_url),
+                )
+            )
+        if protected_image_urls:
+            image_contents.extend(
+                self.create_image_contents(
+                    protected_image_urls,
+                    headers=self._image_headers(page_url, use_auth=True),
+                )
+            )
 
         text = self._build_text(info, title)
         contents: list[MediaContent] = []
@@ -108,15 +134,22 @@ class AllcppParser(BaseParser):
         info = self._parse_work_data(await self._fetch_work(wid))
 
         title = info["title"] or f"图文 {wid}"
+        image_headers = self._image_headers(page_url)
         author = (
-            self.create_author(info["author_name"], avatar_url=info["author_avatar"])
+            self.create_author(
+                info["author_name"],
+                avatar_url=info["author_avatar"],
+                headers=image_headers,
+            )
             if info["author_name"]
             else None
         )
 
         image_urls = self._collect_images(None, info["pics"])
         image_contents: list[MediaContent] = (
-            self.create_image_contents(image_urls) if image_urls else []
+            self.create_image_contents(image_urls, headers=image_headers)
+            if image_urls
+            else []
         )
 
         show_work_content = bool(getattr(self.mycfg, "show_work_content", False))
@@ -155,10 +188,17 @@ class AllcppParser(BaseParser):
 
     async def _fetch_page(self, url: str) -> str:
         """拉取展品详情页 HTML"""
-        async with self.session.get(url, headers=self.headers) as resp:
+        async with self.session.get(url, headers=self.auth_headers) as resp:
             if resp.status >= 400:
                 raise ClientError(f"HTTP {resp.status} {resp.reason}")
             return await resp.text()
+
+    def _image_headers(
+        self, page_url: str, *, use_auth: bool = False
+    ) -> dict[str, str]:
+        """生成图片请求头；仅登录后可见的详情/试阅图片携带 Cookie。"""
+        headers = self.auth_headers if use_auth else self.headers
+        return {**headers, "referer": page_url}
 
     async def _fetch_gallery(self, did: str) -> list[dict[str, Any]]:
         """拉取展品试阅（图集）内容，失败或未登录时返回空列表"""
@@ -166,7 +206,7 @@ class AllcppParser(BaseParser):
         params = {"pageindex": 1, "pagesize": 20, "id": did, "_plat": "web"}
         try:
             async with self.session.get(
-                url, params=params, headers=self.headers
+                url, params=params, headers=self.auth_headers
             ) as resp:
                 if resp.status >= 400:
                     return []
@@ -214,7 +254,7 @@ class AllcppParser(BaseParser):
 
         # 封面（取原图 href，不含 OSS 压缩样式）
         if m := search(r'<a class="djs-info-cover"[^>]*href="([^"]+)"', html_text):
-            info["cover"] = m.group(1).strip()
+            info["cover"] = self._normalize_page_url(m.group(1))
 
         # 标签
         if m := search(r'<ul class="djs-info-tag">(.*?)</ul>', html_text, DOTALL):
@@ -251,8 +291,9 @@ class AllcppParser(BaseParser):
             if p := search(r"<p[^>]*>(.*?)</p>", detail_block, DOTALL):
                 info["detail_text"] = self._clean_detail(p.group(1))
             info["sample_images"] = [
-                u.split("?")[0]
+                url
                 for u in findall(r'<img[^>]*src="([^"]+)"', detail_block)
+                if (url := self._build_content_pic_url(u))
             ]
 
         return info
@@ -260,13 +301,17 @@ class AllcppParser(BaseParser):
     @staticmethod
     def _parse_work_data(work: dict[str, Any]) -> dict[str, Any]:
         """从图文接口数据中提取展示信息"""
-        user = work.get("user") or {}
-        face = user.get("face") or {}
+        user = AllcppParser._as_dict(work.get("user"))
+        face = AllcppParser._as_dict(user.get("face"))
+        author_name = user.get("nickname")
+        author_avatar = face.get("picUrl")
 
         info: dict[str, Any] = {
             "title": work.get("name"),
-            "author_name": user.get("nickname"),
-            "author_avatar": AllcppParser._build_face_url(face.get("picUrl")),
+            "author_name": author_name if isinstance(author_name, str) else None,
+            "author_avatar": AllcppParser._build_face_url(
+                author_avatar if isinstance(author_avatar, str) else ""
+            ),
             "theme": work.get("theme"),
             "type_label": AllcppParser._work_type_label(work.get("type")),
             "hot": work.get("hotCount"),
@@ -324,6 +369,11 @@ class AllcppParser(BaseParser):
             if url:
                 images.append(url)
         return images
+
+    @staticmethod
+    def _as_dict(value: Any) -> dict[str, Any]:
+        """接口字段异常时降级为空对象，避免单个字段导致整个解析失败。"""
+        return value if isinstance(value, dict) else {}
 
     def _extract_gallery_images(self, data: list[dict[str, Any]]) -> list[str]:
         """从试阅接口数据中提取图集图片 URL"""
@@ -422,32 +472,55 @@ class AllcppParser(BaseParser):
 
     @staticmethod
     def _build_pic_url(raw: str) -> str | None:
-        raw = (raw or "").strip()
+        raw = unescape(raw or "").strip()
         if not raw:
             return None
-        if raw.startswith("http"):
+        if raw.startswith(("http://", "https://")):
             return raw
+        if raw.startswith("//"):
+            return f"https:{raw}"
+        if raw.startswith("/upload/"):
+            return f"{PIC_CDN}{raw}"
+        if raw.startswith("upload/"):
+            return f"{PIC_CDN}/{raw}"
         return f"{PIC_CDN}/upload/{raw.lstrip('/')}"
 
     @staticmethod
     def _build_face_url(raw: str) -> str | None:
         """用户头像 URL（/face/ 目录）"""
-        raw = (raw or "").strip()
+        raw = unescape(raw or "").strip()
         if not raw:
             return None
-        if raw.startswith("http"):
+        if raw.startswith(("http://", "https://")):
             return raw
+        if raw.startswith("//"):
+            return f"https:{raw}"
+        if raw.startswith("/face/"):
+            return f"{PIC_CDN}{raw}"
+        if raw.startswith("face/"):
+            return f"{PIC_CDN}/{raw}"
         return f"{PIC_CDN}/face/{raw.lstrip('/')}"
 
     @staticmethod
     def _build_content_pic_url(raw: str) -> str | None:
         """正文内嵌图片 URL（/uupload/image/... 已含目录前缀）"""
-        raw = (raw or "").strip()
+        raw = unescape(raw or "").strip()
         if not raw:
             return None
-        if raw.startswith("http"):
+        if raw.startswith(("http://", "https://")):
             return raw
+        if raw.startswith("//"):
+            return f"https:{raw}"
         return f"{PIC_CDN}/{raw.lstrip('/')}"
+
+    @staticmethod
+    def _normalize_page_url(raw: str) -> str | None:
+        """将详情页里引用的封面地址统一为可下载的绝对 HTTP(S) URL。"""
+        value = unescape(raw or "").strip()
+        if not value:
+            return None
+        url = urljoin(SITE_BASE, value)
+        return url if url.startswith(("http://", "https://")) else None
 
     @staticmethod
     def _clean_text(text: str) -> str:

--- a/core/parsers/allcpp.py
+++ b/core/parsers/allcpp.py
@@ -119,7 +119,15 @@ class AllcppParser(BaseParser):
             self.create_image_contents(image_urls) if image_urls else []
         )
 
-        text = self._build_work_text(info, title)
+        show_work_content = bool(getattr(self.mycfg, "show_work_content", False))
+        max_length = int(getattr(self.mycfg, "text_max_length", 100) or 100)
+
+        text = self._build_work_text(
+            info,
+            title,
+            show_work_content=show_work_content,
+            max_length=max_length,
+        )
         contents: list[MediaContent] = []
         if text:
             contents.append(TextContent(text))
@@ -361,7 +369,13 @@ class AllcppParser(BaseParser):
         return "\n".join(parts) if parts else None
 
     @staticmethod
-    def _build_work_text(info: dict[str, Any], title: str) -> str | None:
+    def _build_work_text(
+        info: dict[str, Any],
+        title: str,
+        *,
+        show_work_content: bool = False,
+        max_length: int = 100,
+    ) -> str | None:
         parts: list[str] = []
         if title:
             parts.append(title)
@@ -377,9 +391,21 @@ class AllcppParser(BaseParser):
             parts.append(f"热度：{info['hot']}")
         if info.get("foreword"):
             parts.append(info["foreword"])
-        if info.get("content"):
+        # 正文：图片类始终展示；文字类受「显示正文」配置控制
+        if info.get("content") and (
+            info.get("type_label") != "文字" or show_work_content
+        ):
             parts.append(info["content"])
-        return "\n".join(parts) if parts else None
+        text = "\n".join(parts) if parts else None
+        # 仅文字类图文限制字数，图片类不截断
+        if (
+            text
+            and info.get("type_label") == "文字"
+            and max_length > 0
+            and len(text) > max_length
+        ):
+            text = text[: max_length - 1] + "…"
+        return text
 
     @staticmethod
     def _collect_images(cover: str | None, gallery: list[str]) -> list[str]:
@@ -431,9 +457,10 @@ class AllcppParser(BaseParser):
 
     @staticmethod
     def _clean_detail(text: str) -> str:
-        """清理展品详情文字：去 <img>、<br> 换行、去空白行"""
+        """清理 HTML 文字：去标签、<br>/</p> 换行、去空白行"""
         text = unescape(text or "")
-        text = sub(r"<img[^>]*>", "", text)
-        text = text.replace("<br>", "\n").replace("<br/>", "\n")
+        text = sub(r"<br\s*/?>", "\n", text)
+        text = sub(r"</p>", "\n", text)
+        text = sub(r"<[^>]+>", "", text)
         lines = [line.strip() for line in text.split("\n")]
         return "\n".join(line for line in lines if line)

--- a/core/parsers/allcpp.py
+++ b/core/parsers/allcpp.py
@@ -214,7 +214,7 @@ class AllcppParser(BaseParser):
                 if resp.status >= 400:
                     return []
                 data = await resp.json()
-        except (ClientError, ValueError):
+        except (ClientError, TimeoutError, ValueError):
             return []
         return data if isinstance(data, list) else []
 
@@ -227,7 +227,7 @@ class AllcppParser(BaseParser):
                     raise ClientError(f"HTTP {resp.status} {resp.reason}")
                 text = await resp.text()
                 data = json.loads(text) if text.strip() else None
-        except (ClientError, ValueError):
+        except (ClientError, TimeoutError, ValueError):
             raise ParseException(f"图文 {wid} 不存在或已删除")
         if not isinstance(data, dict) or not data.get("id"):
             raise ParseException(f"图文 {wid} 不存在或已删除")

--- a/core/parsers/allcpp.py
+++ b/core/parsers/allcpp.py
@@ -563,6 +563,9 @@ class AllcppParser(BaseParser):
             r"(?:shiyueUrl|otherUrl)\s*[:=]\s*[\"']([^\"']+)[\"']",
             unescape(content or ""),
         )
+        values = [
+            f"https:{url}" if url.startswith("//") else url for url in values
+        ]
         return AllcppParser._deduplicate_links(values)
 
     @staticmethod

--- a/default_template.json
+++ b/default_template.json
@@ -38,5 +38,11 @@
     "cookies": "",
     "show_body_text": true,
     "video_send_mode": "first"
+  },
+  {
+    "__template_key": "allcpp",
+    "enable": true,
+    "use_proxy": false,
+    "cookies": ""
   }
 ]

--- a/default_template.json
+++ b/default_template.json
@@ -43,6 +43,8 @@
     "__template_key": "allcpp",
     "enable": true,
     "use_proxy": false,
-    "cookies": ""
+    "cookies": "",
+    "show_work_content": false,
+    "text_max_length": 100
   }
 ]

--- a/default_template.json
+++ b/default_template.json
@@ -38,13 +38,5 @@
     "cookies": "",
     "show_body_text": true,
     "video_send_mode": "first"
-  },
-  {
-    "__template_key": "allcpp",
-    "enable": true,
-    "use_proxy": false,
-    "cookies": "",
-    "show_work_content": false,
-    "text_max_length": 100
   }
 ]


### PR DESCRIPTION
## 新增 AllCPP 无差别同人站解析器

### 前言
最近经常时候分享allcpp.cn的链接，因此想要添加一个allcpp.cn支持的解析器

### 思路

通过匹配 AllCPP 展品、图文和短链接，获取页面或公开接口中的内容，再统一转换为插件现有的文本、图片发送结果。

- 展品页以详情页 HTML 为基础，补充试阅接口内容。
- 图文页直接使用 AllCPP 的 REST 接口获取数据。
- 登录 Cookie 仅用于需要登录权限的展品详情与试阅内容。
- 图片、文本和试阅外链按插件原有发送策略输出。

## 功能

### 展品链接解析

- 支持解析 AllCPP 展品链接：
  - `https://www.allcpp.cn/d/<id>.do`
  - `https://icp.red/<short_code>`
- 支持解析标题、作者、标签、热度、状态和详情文字。
- 支持解析展品封面、试阅图集和试阅图片。
- 支持解析图文试阅中的外部链接。
- 支持解析展品级试阅外链 `shiyueUrl` / `otherUrl`。
- 外部链接会自动去重，过滤 AllCPP 站内地址后随消息发送。

### 图文链接解析

- 支持解析 AllCPP 图文链接：
  - `https://www.allcpp.cn/w/<id>.do`
- 解析标题、作者、头像、主题、类型、标签、热度、前言和正文。
- 支持提取图文正文中的图片并发送。
- 文字类图文可配置是否显示正文及最大文字长度。

### Cookie 与图片下载

- 未配置 Cookie 时，可解析公开展品封面和公开图文内容。
- 配置 Cookie 后，可解析登录后可见的展品详情和试阅图集。
- Cookie 仅用于展品详情、试阅接口及受保护试阅图片。
- 公开封面、图文图片和头像不携带 Cookie。
- 图片请求携带详情页 Referer，兼容 AllCPP CDN 防盗链。
- 兼容完整 URL、协议相对 URL 与 AllCPP CDN 相对路径。

## 配置项

| 配置项 | 类型 | 默认值 | 说明 |
| --- | --- | --- | --- |
| `enable` | `bool` | `true` | 是否启用 AllCPP 解析器。 |
| `use_proxy` | `bool` | `false` | 是否使用插件配置的代理。 |
| `cookies` | `text` | 空 | AllCPP 登录 Cookie。配置后可获取登录后可见的展品详情与试阅图集。 |
| `show_work_content` | `bool` | `false` | 是否显示文字类图文的正文内容。图片仍会正常发送。 |
| `text_max_length` | `int` | `100` | 文字类图文消息最大字数。设为 `0` 或留空时按默认值 `100` 处理。 |

## Sourcery 总结

新增 AllCPP 解析器，可将展览和图文内容链接转换为可配置的文本和媒体消息。

新功能：
- 支持 AllCPP 解析展览、短链接和图文内容 URL，并转换为文本和图片消息。
- 支持展览元数据、封面、预览图库、预览链接以及需要身份验证的内容获取。
- 支持图文内容元数据、作者信息、嵌入图片，以及可配置的文本显示和截断。

增强功能：
- 区分公开资源和需要身份验证的资源访问，包括 Cookie 隔离和 CDN Referer 要求。
- 统一并去重不同 AllCPP 响应格式中的媒体和外部链接。

维护工作：
- 在插件配置架构和默认配置中注册 AllCPP 解析器及其配置选项。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为展览和图文内容添加可配置的 AllCPP 链接解析功能。

新功能：
- 添加 AllCPP 解析器，用于处理展览、短链接和图文内容 URL，并将元数据、文本、图片、预览内容和外部链接转换为插件消息。

增强功能：
- 支持公共资源和经过身份验证的资源分别访问，包括可选 Cookie 和兼容 CDN 的图片引用来源。
- 支持配置图文内容的文本显示和长度限制，同时对提取的媒体和外部链接进行去重。

维护工作：
- 在插件配置架构和默认配置中注册 AllCPP 解析器及其配置选项。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为展览和图文内容添加可配置的 AllCPP 链接解析功能。

新功能：
- 添加 AllCPP 解析器，支持处理展览、短链接和图文内容 URL，并将其元数据、文本和图片转换为插件消息。
- 支持展览封面、预览图库、预览链接、作品元数据、作者信息和嵌入式图片。

增强功能：
- 分离公共和需身份验证的 AllCPP 资源访问，支持可选 Cookie 和兼容 CDN 的图片引用来源。
- 对提取的图片和外部链接进行去重，同时过滤 AllCPP 内部 URL。
- 允许配置基于文本的图文内容的显示和长度限制。

维护事项：
- 在配置架构和默认配置中注册 AllCPP 解析器及其配置选项。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为展览和图文内容添加可配置的 AllCPP 链接解析功能。

新功能：
- 添加 AllCPP 解析器，支持展览、短链接和图文内容 URL，并输出文本和媒体内容。
- 提取 AllCPP 元数据、封面、预览图库、嵌入图片和外部预览链接，包括需要身份验证的展览内容。

增强功能：
- 支持分别请求公开资源和需要身份验证的资源，可选使用 Cookie 和兼容 CDN 的 Referrer。
- 对提取的图片和外部链接去重，同时过滤 AllCPP 内部 URL。
- 支持配置图文内容正文的可见性和文本长度限制。

维护工作：
- 在插件配置 schema 和解析器注册表中注册 AllCPP 解析器及其配置选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable AllCPP link parsing for exhibitions and illustrated content.

New Features:
- Add an AllCPP parser supporting exhibition, short-link, and illustrated-content URLs with text and media output.
- Extract AllCPP metadata, covers, preview galleries, embedded images, and external preview links, including authenticated exhibition content.

Enhancements:
- Support separate public and authenticated resource requests with optional cookies and CDN-compatible referrers.
- Deduplicate extracted images and external links while filtering AllCPP-internal URLs.
- Allow configuration of illustrated-content body visibility and text length limits.

Chores:
- Register the AllCPP parser and its configuration options in the plugin configuration schema and parser registry.

</details>

</details>

</details>

</details>